### PR TITLE
fix(security): validate vendor paths before refresh writes

### DIFF
--- a/scripts/update-vendor.mjs
+++ b/scripts/update-vendor.mjs
@@ -32,6 +32,27 @@ function ensureString(value, fieldPath) {
   return value.trim();
 }
 
+
+function ensureVendorPath(rawPath, fieldPath) {
+  const relativePath = ensureString(rawPath, fieldPath);
+  if (path.isAbsolute(relativePath)) {
+    fail(`Invalid manifest at ${fieldPath}: expected relative path`);
+  }
+
+  const normalized = path.posix.normalize(relativePath);
+  if (normalized !== relativePath) {
+    fail(`Invalid manifest at ${fieldPath}: path must already be normalized`);
+  }
+  if (!normalized.startsWith('js/vendor/')) {
+    fail(`Invalid manifest at ${fieldPath}: path must stay under js/vendor/`);
+  }
+  if (normalized.includes('../') || normalized === '..') {
+    fail(`Invalid manifest at ${fieldPath}: path traversal is not allowed`);
+  }
+
+  return normalized;
+}
+
 function ensureHttpsUrl(rawUrl, fieldPath) {
   const urlString = ensureString(rawUrl, fieldPath);
   let parsed;
@@ -108,7 +129,7 @@ function listManifestFiles(manifest) {
       const fieldPath = `manifest.dependencies[${dependencyIndex}].files[${fileIndex}]`;
       const fileObject = ensureObject(fileEntry, fieldPath);
       const upstreamUrl = ensureHttpsUrl(fileObject.upstream_url, `${fieldPath}.upstream_url`);
-      const relativePath = ensureString(fileObject.path, `${fieldPath}.path`);
+      const relativePath = ensureVendorPath(fileObject.path, `${fieldPath}.path`);
       const signatures = Array.isArray(fileObject.signatures) ? fileObject.signatures.map((signature, signatureIndex) =>
         ensureString(signature, `${fieldPath}.signatures[${signatureIndex}]`)
       ) : fail(`Invalid manifest at ${fieldPath}.signatures: expected non-empty array`);
@@ -282,6 +303,7 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
 
 export {
   ensureHttpsUrl,
+  ensureVendorPath,
   fetchVendorFiles,
   parseArgs,
   runVendorRefresh,

--- a/tests/security/vendor-refresh.test.mjs
+++ b/tests/security/vendor-refresh.test.mjs
@@ -6,6 +6,7 @@ import test from 'node:test';
 
 import {
   ensureHttpsUrl,
+  ensureVendorPath,
   fetchVendorFiles,
   parseArgs,
   runVendorRefresh,
@@ -58,6 +59,13 @@ test('parseArgs defaults to dry-run and validates known flags', () => {
   assert.throws(() => parseArgs(['--bogus']), /Unknown argument/);
 });
 
+
+
+test('ensureVendorPath rejects traversal and non-vendor paths', () => {
+  assert.equal(ensureVendorPath('js/vendor/workbox/test-file.js', 'file.path'), 'js/vendor/workbox/test-file.js');
+  assert.throws(() => ensureVendorPath('../pwned.txt', 'file.path'), /path must stay under js\/vendor\//);
+  assert.throws(() => ensureVendorPath('scripts/build.js', 'file.path'), /path must stay under js\/vendor\//);
+});
 test('fetchVendorFiles downloads upstream content and verifies signatures', async () => {
   const manifest = makeManifest();
   const payload = '/* workbox:test:9.9.9 */\nconsole.log("test-file.js");\n';


### PR DESCRIPTION
### Motivation
- Prevent a supply-chain developer-workstation arbitrary file overwrite where `scripts/update-vendor.mjs` accepted manifest `path` entries with only an `ensureString` check and wrote them before governance validation. 
- Enforce the existing policy that vendored files must remain under `js/vendor/` early in the refresh workflow to close the write-before-validate window.

### Description
- Add `ensureVendorPath()` to `scripts/update-vendor.mjs` which enforces: relative path only, already-normalized (`path.posix.normalize`), no `..` traversal, and must start with `js/vendor/`.
- Use `ensureVendorPath()` when parsing manifest `file.path` entries in `listManifestFiles()` so manifest paths are validated before any fetch or write occurs.
- Export `ensureVendorPath` for testability and add a regression test in `tests/security/vendor-refresh.test.mjs` that asserts traversal and non-vendor paths are rejected.
- Changes are minimal and preserve existing manifest fetching, signature checking, and manifest hash update behavior.

### Testing
- Ran the focused unit test file with `node --test tests/security/vendor-refresh.test.mjs`, which passed (6 tests, 0 failures) and includes a regression test that covers traversal and non-vendor path rejection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d67ebab4832a90f10bc4c2d5f441)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive security tests for vendor file path validation to ensure safe file handling and prevent unauthorized directory traversal.

* **Chores**
  * Enhanced vendor file manifest validation with improved path verification to ensure all files remain properly organized within designated vendor directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/leonardwongly/ProjectPortfolio/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->