### PR TITLE
fix(security): harden validation and vendor fetches

### DIFF
--- a/.github/workflows/playwright-integration.yml
+++ b/.github/workflows/playwright-integration.yml
@@ -26,7 +26,7 @@ jobs:
           cache: npm
 
       - name: Install Node dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install Chromium for Playwright
         run: ./node_modules/.bin/playwright install --with-deps chromium

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -38,3 +38,9 @@ jobs:
 
       - name: Run security and content tests
         run: npm run test:security
+
+      - name: Run high severity dependency audit
+        run: npm run audit:high
+
+      - name: Validate vendored dependency governance
+        run: npm run validate:vendor:governance

--- a/docs/security/csp-monitoring.md
+++ b/docs/security/csp-monitoring.md
@@ -1,0 +1,66 @@
+# CSP Monitoring Runbook
+
+This repository enforces Content Security Policy through `src/_headers.template`,
+generated `_headers`, and the source-page meta CSP tags. There is no committed
+CSP report collector endpoint today. Until a collector is provisioned, CSP
+monitoring is handled through the release checks below so the absence of an
+endpoint is explicit and reviewable.
+
+## Current Operating Mode
+
+- CSP enforcement remains active in response headers and source-page meta tags.
+- No `report-uri` or `report-to` directive should be added without a real,
+  approved HTTPS collector endpoint.
+- Do not point CSP reports at a placeholder route on this static site. Browsers
+  send violation reports with `POST`, and Cloudflare Pages static assets are not
+  a report ingestion service.
+
+## Release Review
+
+For every production release or header-policy change:
+
+1. Run the local release gate:
+   ```bash
+   npm run validate:full
+   ```
+2. Verify deployed headers:
+   ```bash
+   curl -sSI https://leonardwong.tech/ | rg -i "^(content-security-policy|strict-transport-security|permissions-policy|x-frame-options|x-content-type-options|referrer-policy|access-control-allow-origin):"
+   curl -sSI https://leonardwong.tech/reading | rg -i "^(content-security-policy|strict-transport-security|permissions-policy|x-frame-options|x-content-type-options|referrer-policy|access-control-allow-origin):"
+   curl -sSI https://leonardwong.tech/offline | rg -i "^(content-security-policy|strict-transport-security|permissions-policy|x-frame-options|x-content-type-options|referrer-policy|access-control-allow-origin):"
+   ```
+3. Open the deployed pages in a browser with developer tools and confirm there
+   are no CSP violations in the console.
+4. Review Cloudflare Pages deployment output and Cloudflare security events for
+   unexpected blocked resources, injected script attempts, or repeated requests
+   for undeployed assets.
+
+## Collector Rollout Requirements
+
+If a CSP collector is later provisioned, complete all of these steps in the same
+change:
+
+1. Confirm the endpoint is HTTPS, production-owned, and able to accept browser
+   CSP report `POST` requests.
+2. Confirm report retention, access control, and alert ownership. Reports can
+   include document URLs and blocked URLs, so avoid broad access and long
+   retention by default.
+3. Add `report-uri` and/or `report-to` to `src/_headers.template` without
+   relaxing the existing CSP directives.
+4. Run `npm run build` so `_headers` is regenerated from the template.
+5. Update security tests to assert the reporting directive and endpoint.
+6. Trigger a controlled CSP violation in a non-production or preview deployment
+   and verify the collector receives it before enabling alerts for production.
+
+## Escalation
+
+Treat any unexpected CSP violation, repeated blocked script/style load, or
+unknown external resource reference as a security investigation. The first
+checks are:
+
+1. Compare the deployed `_headers` against the committed `_headers`.
+2. Inspect the page source for unexpected inline scripts or external resources.
+3. Check recent dependency, vendor, template, and generated-file changes.
+4. Re-run `npm run test:security` and `npm run validate:vendor`.
+5. Revert the release or redeploy the last known-good Cloudflare Pages build if
+   the violation points to an unauthorized source.

--- a/docs/security/deployment-headers.md
+++ b/docs/security/deployment-headers.md
@@ -36,3 +36,11 @@ Expected:
 1. Each endpoint returns all required security headers listed above.
 2. `Content-Security-Policy` includes `style-src 'self'` and `frame-ancestors 'none'`.
 3. `Access-Control-Allow-Origin` for HTML responses is `https://leonardwong.tech`.
+
+## CSP Monitoring
+
+CSP enforcement is repo-owned through `src/_headers.template` and generated
+`_headers`. CSP reporting is not enabled until a real HTTPS collector endpoint is
+approved and tested. Use `docs/security/csp-monitoring.md` for the current
+manual review process and the required rollout steps before adding `report-uri`
+or `report-to`.

--- a/docs/security/security-assessment-2026-05-28.md
+++ b/docs/security/security-assessment-2026-05-28.md
@@ -1,0 +1,324 @@
+# Security Assessment - 2026-05-28
+
+## Executive Summary
+
+The ProjectPortfolio codebase is a static portfolio/PWA with no server-side application logic, database layer, authentication system, session management, administrative interface, container configuration, or application API endpoints in the repository. The overall application security posture is strong for a static site: generated HTML is produced from structured JSON, untrusted display data is consistently escaped, URLs and asset paths are validated, strict CSP/security headers are generated, service-worker update messages are schema/origin checked, vendored Workbox files are hash-governed, GitHub Actions are mostly SHA-pinned with minimal permissions, and dependency audit results are clean.
+
+No critical or high-severity exploitable vulnerability was identified in first-party application code. I did not find hardcoded secrets, backdoor accounts, hidden administrative functionality, obfuscated first-party code, unauthorized persistence, covert command-and-control behavior, suspicious telemetry, credential exfiltration logic, insecure deserialization, direct RCE vectors, CSRF-relevant state-changing endpoints, SQL/database injection surfaces, or authentication/authorization bypass paths.
+
+The main findings were operational and supply-chain oriented:
+
+- Network-check scripts can be abused as limited SSRF primitives when run against attacker-controlled content because they validate only URL shape and literal private hosts, not DNS-resolved private addresses.
+- One pull-request integration workflow runs `npm ci` without `--ignore-scripts`, allowing dependency lifecycle scripts to execute in CI if a PR changes dependency metadata.
+- The default PR build/scan workflows do not run the full dependency/vendor gates before merge.
+- There is no repo-owned CSP violation collection path, so browser-side policy violations may be harder to detect.
+
+## Remediation Status
+
+This branch remediates the actionable repository-side findings from this assessment:
+
+- PP-SA-001 and PP-SA-002 add URL-shape validation, public-host allowlisting for vendor upstreams, and DNS preflight rejection of private or reserved A/AAAA answers before link-health and vendor-refresh fetches. The remaining limitation is DNS rebinding/TOCTOU between preflight and the actual fetch; the scripts are maintainer-side CI/developer controls for repository content, not a complete network sandbox.
+- PP-SA-003 changes the Playwright integration workflow to install dependencies with `npm ci --ignore-scripts`.
+- PP-SA-004 adds `npm run audit:high` and `npm run validate:vendor:governance` to the default PR scan workflow while keeping networked upstream vendor refresh in the explicit/scheduled validation path.
+- PP-SA-005 adds `docs/security/csp-monitoring.md` and runbook references for Cloudflare/security-event review and future collector rollout. The repo still intentionally omits `report-uri` and `report-to` until a real approved HTTPS collector exists.
+
+Validation for this remediation should include `npm run validate:full`, `git diff --check`, and post-merge GitHub required checks: `Build`, `Scan`, `CodeQL`, and `Cloudflare Pages`.
+
+## Scope Reviewed
+
+Reviewed source and generated surfaces:
+
+- Static source pages and generated pages: `src/*.html`, `index.html`, `reading.html`, `offline.html`
+- Client scripts: `js/main.js`, `js/site.js`, `pwabuilder-sw.js`
+- Build and operational scripts: `scripts/*.js`, `scripts/*.mjs`
+- Structured content inputs: `data/*.json`
+- Security headers and PWA metadata: `src/_headers.template`, `_headers`, `manifest.json`, `robots.txt`, `sitemap.xml`
+- Vendored dependencies: `js/vendor/**`, Bootstrap/Workbox assets, `docs/security/vendor-dependencies.json`
+- CI/CD and automation: `.github/workflows/*.yml`, `.github/dependabot.yml`
+- Tests and existing security controls: `tests/security/*.mjs`, `tests/integration/*.mjs`
+- Dependency manifests: `package.json`, `package-lock.json`
+
+## Findings
+
+### PP-SA-001 - Link health checker can perform DNS-based SSRF
+
+Severity: Medium
+
+Location:
+
+- `scripts/check-link-health.mjs:51-92`
+- `scripts/check-link-health.mjs:153-178`
+
+Evidence:
+
+```js
+function isPrivateLiteralHost(hostname) {
+  const lower = hostname.toLowerCase();
+  if (lower === 'localhost' || lower.endsWith('.localhost')) return true;
+  if (lower === '0.0.0.0') return true;
+  const ipVersion = net.isIP(lower);
+  ...
+  return false;
+}
+...
+return await fetch(url, {
+  method,
+  redirect: 'manual',
+  signal: controller.signal,
+  headers: {
+    'user-agent': 'ProjectPortfolio-link-health/1.0',
+    connection: 'close'
+  }
+});
+```
+
+Exploitation scenario:
+
+An attacker who can get a URL into `data/profile.json`, `data/certifications.json`, `data/featured-projects.json`, generated HTML, or a branch that a maintainer checks with `npm run check:links` can point an HTTPS URL at an attacker-controlled hostname whose DNS resolves to a private/internal address. The script blocks literal private IPs and `localhost`, but it does not resolve hostnames before issuing `fetch`.
+
+Potential impact:
+
+When run on a developer machine or CI runner, the script can make HEAD/GET requests from that environment to otherwise private HTTPS endpoints. Because redirects are manual and only HTTPS is allowed, impact is constrained, but it can still be used for internal reachability probing or limited interaction with internal services.
+
+Root cause:
+
+Host validation is string-based and only catches literal private hosts. It does not perform DNS resolution and reject private, loopback, link-local, multicast, or reserved address ranges for every A/AAAA answer.
+
+Remediation:
+
+1. Resolve hostnames with `dns.promises.lookup(hostname, { all: true, verbatim: true })` before `fetch`.
+2. Reject all private, loopback, link-local, multicast, documentation, carrier-grade NAT, and unspecified IPv4/IPv6 ranges.
+3. Consider an explicit allowlist for known public domains used by the portfolio, or disable network link checks for untrusted PR content.
+4. Add regression tests covering DNS names that resolve to private IPv4/IPv6 addresses.
+
+### PP-SA-002 - Vendor refresh can fetch attacker-controlled internal hosts
+
+Severity: Medium
+
+Location:
+
+- `scripts/update-vendor.mjs:56-72`
+- `scripts/update-vendor.mjs:148-160`
+- `docs/security/vendor-dependencies.json:7-56`
+
+Evidence:
+
+```js
+function ensureHttpsUrl(rawUrl, fieldPath) {
+  const urlString = ensureString(rawUrl, fieldPath);
+  const parsed = new URL(urlString);
+  if (parsed.protocol !== 'https:') {
+    fail(`Invalid manifest at ${fieldPath}: only https URLs are allowed`);
+  }
+  if (parsed.username || parsed.password) {
+    fail(`Invalid manifest at ${fieldPath}: credentials in URL are not allowed`);
+  }
+  return parsed.toString();
+}
+...
+return await fetchImpl(url, {
+  method: 'GET',
+  redirect: 'error',
+  signal: controller.signal,
+  headers: {
+    'accept': 'application/javascript, text/javascript, text/plain;q=0.9, */*;q=0.1'
+  }
+});
+```
+
+Exploitation scenario:
+
+If an attacker can alter `docs/security/vendor-dependencies.json` in a branch and convince a maintainer or automation to run `npm run validate:vendor`, the refresh script can make HTTPS GET requests to arbitrary hostnames. The manifest currently points only to Google Workbox CDN URLs, but the script does not enforce that host or block DNS-resolved private addresses.
+
+Potential impact:
+
+The signature and hash checks reduce supply-chain write risk after the response is fetched, but the outbound request itself can still be abused for limited internal network probing from the developer or runner environment.
+
+Root cause:
+
+The vendor updater validates protocol and credentials, but not hostname allowlist, DNS resolution, or reserved address ranges.
+
+Remediation:
+
+1. Restrict `upstream_url` hosts to an allowlist matching the declared dependency source, currently `storage.googleapis.com`.
+2. Add DNS resolution and private-address rejection before `fetch`.
+3. Keep `redirect: 'error'` and hash/signature validation as-is.
+4. Add tests proving non-allowlisted hosts, private literal hosts, and private DNS answers are rejected.
+
+### PP-SA-003 - PR integration workflow allows dependency lifecycle scripts
+
+Severity: Medium
+
+Location:
+
+- `.github/workflows/playwright-integration.yml:28-35`
+
+Evidence:
+
+```yaml
+- name: Install Node dependencies
+  run: npm ci
+
+- name: Install Chromium for Playwright
+  run: ./node_modules/.bin/playwright install --with-deps chromium
+
+- name: Run nav and accordion integration spec
+  run: ./node_modules/.bin/playwright test tests/integration/mobile-nav-and-accordion.spec.mjs --config=playwright.config.mjs
+```
+
+Exploitation scenario:
+
+The workflow runs on pull requests. A malicious dependency change in a PR can cause npm lifecycle scripts to execute during `npm ci`. The workflow has read-only repository permissions and no explicit repository secrets, which limits blast radius, but lifecycle execution still provides arbitrary code execution in the CI runner during installation.
+
+Potential impact:
+
+CI runner reconnaissance, network egress, artifact poisoning, dependency-cache pollution, or exfiltration of low-sensitivity runtime context such as read-only `GITHUB_TOKEN` metadata. This is less severe than a write-token workflow compromise, but it is avoidable.
+
+Root cause:
+
+The build and scan workflows use `npm ci --ignore-scripts`, but the Playwright integration workflow does not.
+
+Remediation:
+
+1. Change `.github/workflows/playwright-integration.yml` to `npm ci --ignore-scripts`.
+2. Keep browser installation explicit with `./node_modules/.bin/playwright install --with-deps chromium`.
+3. Consider mirroring this in all local validation docs so dependency scripts remain disabled by default.
+
+### PP-SA-004 - Default PR gates omit dependency and vendor governance checks
+
+Severity: Low
+
+Location:
+
+- `.github/workflows/build.yml:21-28`
+- `.github/workflows/scan.yml:30-40`
+- `.github/workflows/vendor-review.yml:27-34`
+- `package.json:15-22`
+
+Evidence:
+
+Build/scan run only build, generated-file drift, and security tests:
+
+```yaml
+- name: Install Node dependencies
+  run: npm ci --ignore-scripts
+- name: Build generated pages
+  run: npm run build
+- name: Ensure generated files are committed
+  run: git diff --exit-code -- index.html reading.html offline.html _headers
+- name: Run security and content tests
+  run: npm run test:security
+```
+
+The fuller local gate includes additional checks:
+
+```json
+"validate:full": "npm run build && npm run check:generated && npm run test:security && npm run check:reading && npm run check:performance && npm run audit:high && npm run validate:vendor && npm run test:integration"
+```
+
+Exploitation scenario:
+
+A dependency or vendor governance regression could pass the default PR build/scan and be detected only later by scheduled/manual vendor review or by a maintainer running `validate:full`.
+
+Potential impact:
+
+Delayed detection of stale vendored assets, dependency advisories, or performance/reading metadata regressions. Current impact is low because dependency count is small and scheduled vendor review exists.
+
+Root cause:
+
+The CI fast path and local full validation path have drifted.
+
+Remediation:
+
+1. Add `npm run audit:high` to the default PR scan.
+2. Add `npm run validate:vendor` after hardening PP-SA-002, or run a non-network governance-only subset on PRs and keep upstream checks scheduled.
+3. Keep Playwright integration enabled for ready-for-review PRs after fixing PP-SA-003.
+
+### PP-SA-005 - CSP violation monitoring is not repo-owned
+
+Severity: Low
+
+Location:
+
+- `src/_headers.template:8-21`
+- `_headers:8-21`
+
+Evidence:
+
+The deployed CSP is strict, but it has no `report-uri` or `report-to` directive:
+
+```http
+Content-Security-Policy: default-src 'self'; script-src 'self'{{CSP_SCRIPT_HASHES}}; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
+```
+
+Exploitation scenario:
+
+If an injection, extension interaction, compromised dependency, or hosting misconfiguration causes CSP violations in browsers, the repository has no configured reporting endpoint to collect that signal.
+
+Potential impact:
+
+Lower detection and triage capability for attempted or accidental client-side policy violations. This does not weaken preventive CSP enforcement.
+
+Root cause:
+
+The repo defines enforcement headers but not reporting or incident-monitoring plumbing.
+
+Remediation:
+
+1. Add a CSP reporting endpoint if Cloudflare, a static-compatible collector, or another monitoring target is available.
+2. Use `report-to` and/or `report-uri` where supported.
+3. Add periodic review of Cloudflare security events and Pages deploy headers.
+
+## Suspicious or Malicious Code Review
+
+No intentionally malicious or suspicious first-party behavior was identified.
+
+Not observed:
+
+- Hardcoded private keys, passwords, API keys, OAuth refresh tokens, or backdoor credentials.
+- Hidden administrative routes or undocumented privileged UI.
+- Obfuscated first-party JavaScript.
+- Dynamic code execution in first-party source (`eval`, `new Function`, string `setTimeout`/`setInterval`).
+- Remote command execution paths in runtime browser code.
+- Covert network beacons, WebSockets, arbitrary exfiltration endpoints, or unauthorized telemetry. The only telemetry adapter in `js/main.js` pushes sanitized event names/properties to already-present analytics globals and dispatches a local `CustomEvent`; CSP currently restricts `connect-src` to `self`.
+- Persistence mechanisms beyond standard service-worker caching and `localStorage` for theme preference.
+
+## Positive Security Controls
+
+- Generated content is escaped with `escapeHtml` and JSON-LD is protected with `escapeJsonLd` in `scripts/build.js`.
+- Data schemas enforce allowed keys, length limits, URL protocol restrictions, credential stripping, and asset path traversal prevention.
+- Generated pages use a strict CSP without `unsafe-inline` or `unsafe-eval`; inline script hashes are computed and injected.
+- Runtime `_headers` include HSTS, `Referrer-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Permissions-Policy`, and CSP.
+- Production header spot checks on 2026-05-28 confirmed Cloudflare serves the expected CSP, HSTS, referrer, permissions, no-sniff, and frame-denial headers for `/`, `/reading`, and `/offline`.
+- `target="_blank"` links include `rel="noopener noreferrer"`.
+- Service-worker `skipWaiting` messages require same-origin window clients and message shape validation.
+- Vendored Workbox files have a manifest with declared upstream URLs, sha256 hashes, signature checks, inventory checks, and review-age enforcement.
+- GitHub Actions are SHA-pinned and generally use least-privilege permissions with `persist-credentials: false`.
+- Gemini automation separates planning from write-capable execution, requires trusted collaborator approval, validates exact `plan#<uuid> approved` syntax, requires a GitHub App token for write operations, and prevents direct commits to `main`.
+
+## Validation Performed
+
+Commands run:
+
+- `npm run validate:full` - failed only at `test:integration` because local `node_modules` was absent and `npx --no-install playwright` resolved to a global Playwright CLI without the `test` command.
+- `npm ci --ignore-scripts` - passed; installed locked dev dependencies locally.
+- `npm run test:integration` - passed after installing locked dependencies; 9 passed, 3 skipped.
+- `npm audit --json` - passed; 0 vulnerabilities.
+- Production header checks with `curl -sSI https://leonardwong.tech/`, `/reading`, and `/offline` - expected security headers present.
+- Static searches for secrets, dangerous browser sinks, message handlers, fetch/network calls, dynamic execution, suspicious tokens, backdoor-like strings, workflow permissions, and vendored dependency controls.
+
+Representative validation results:
+
+- Security tests: 58 passed.
+- High-severity npm audit: 0 vulnerabilities.
+- Vendor governance: 5 vendored files validated; review age 12 days.
+- Vendor upstream review: tracked Workbox dependency is on the latest declared npm release.
+- Performance budgets: all checked assets below configured budgets.
+
+## Prioritized Action Plan
+
+1. Harden network-fetching scripts against DNS-based SSRF: fix `scripts/check-link-health.mjs` and `scripts/update-vendor.mjs` with DNS resolution, reserved-range rejection, and upstream host allowlists.
+2. Change the Playwright PR workflow install step to `npm ci --ignore-scripts`.
+3. Add `npm run audit:high` to PR scan/build gates; add a vendor-governance PR gate after SSRF hardening or split it into non-network and network phases.
+4. Add CSP violation reporting if an endpoint is available.
+5. Keep scheduled CodeQL, Dependabot, and vendor review active, and periodically verify production headers after Cloudflare/Pages configuration changes.

--- a/docs/static-content-runbook.md
+++ b/docs/static-content-runbook.md
@@ -40,7 +40,7 @@ The content parity tests verify that source-backed profile facts such as the cur
 
 The reading audit rejects missing authors, missing ISBNs, invalid years, duplicate ISBN/title-year records, and missing declared cover files. Reading years must be canonical four-digit years or integer years in the accepted range, and generated filter attributes must remain escaped so quote-bearing metadata cannot break out of HTML attributes.
 
-The link-health checker validates URL shape before network access and blocks non-HTTPS, credential-bearing, localhost, and private literal host references. The default mode reports network failures without failing the build; use `npm run check:links -- --strict` before release if you need broken-link enforcement.
+The link-health checker performs URL-shape and DNS preflight checks before fetches and blocks non-HTTPS, credential-bearing, localhost, private literal host, and private DNS-resolved references. This is a maintainer-side hardening control for repository content, not a general-purpose network sandbox; the subsequent fetch still uses the original hostname and therefore depends on resolver stability between preflight and request. The default mode reports network failures without failing the build; use `npm run check:links -- --strict` before release if you need broken-link enforcement.
 
 The performance budget check caps generated page sizes, key static assets, asset directories, and individual book/image/font files. Update `docs/media-asset-policy.md` before changing those budgets.
 
@@ -67,6 +67,7 @@ The Gemini assistant workflow separates planning from execution. Planning can in
 - [ ] `npm run validate:vendor`
 - [ ] `npm run test:integration`
 - [ ] `npm run check:generated` after committing generated files
+- [ ] Review `docs/security/csp-monitoring.md` for CSP console checks and Cloudflare event review when header policy changes.
 - [ ] Verify production security headers after merge:
   ```bash
   curl -sSI https://leonardwong.tech/ | rg -i "^(content-security-policy|strict-transport-security|permissions-policy|x-frame-options|x-content-type-options|referrer-policy):"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "check:links": "node scripts/check-link-health.mjs",
     "check:performance": "node scripts/check-performance-budget.mjs",
     "check:reading": "node scripts/audit-reading-metadata.mjs",
-    "validate:vendor": "node scripts/check-vendor-governance.mjs && node scripts/update-vendor.mjs && node scripts/check-vendor-upstream.mjs",
+    "validate:vendor:governance": "node scripts/check-vendor-governance.mjs",
+    "validate:vendor:upstream": "node scripts/update-vendor.mjs && node scripts/check-vendor-upstream.mjs",
+    "validate:vendor": "npm run validate:vendor:governance && npm run validate:vendor:upstream",
     "validate": "npm run build && npm run test:security",
     "validate:full": "npm run build && npm run check:generated && npm run test:security && npm run check:reading && npm run check:performance && npm run audit:high && npm run validate:vendor && npm run test:integration"
   },

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const integrationPort = Number.parseInt(process.env.PLAYWRIGHT_PORT || '4173', 10);
+const integrationBaseURL = `http://127.0.0.1:${integrationPort}`;
+
 export default defineConfig({
   testDir: './tests/integration',
   timeout: 30_000,
@@ -9,14 +12,14 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: [['list']],
   use: {
-    baseURL: 'http://127.0.0.1:4173',
+    baseURL: integrationBaseURL,
     trace: 'on-first-retry',
     serviceWorkers: 'block'
   },
   webServer: {
-    command: 'python3 -m http.server 4173 --bind 127.0.0.1',
-    url: 'http://127.0.0.1:4173/index.html',
-    reuseExistingServer: !process.env.CI,
+    command: `python3 -m http.server ${integrationPort} --bind 127.0.0.1`,
+    url: `${integrationBaseURL}/index.html`,
+    reuseExistingServer: false,
     timeout: 120_000
   },
   projects: [

--- a/scripts/check-link-health.mjs
+++ b/scripts/check-link-health.mjs
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
-import net from 'node:net';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { assertPublicHttpsUrl, normalizePublicHttpsUrl } from './lib/network-safety.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -48,48 +49,21 @@ function parseArgs(argv = process.argv.slice(2)) {
   return options;
 }
 
-function isPrivateLiteralHost(hostname) {
-  const lower = hostname.toLowerCase();
-  if (lower === 'localhost' || lower.endsWith('.localhost')) return true;
-  if (lower === '0.0.0.0') return true;
-
-  const ipVersion = net.isIP(lower);
-  if (ipVersion === 4) {
-    const parts = lower.split('.').map((part) => Number.parseInt(part, 10));
-    return (
-      parts[0] === 10 ||
-      parts[0] === 127 ||
-      (parts[0] === 169 && parts[1] === 254) ||
-      (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
-      (parts[0] === 192 && parts[1] === 168)
-    );
-  }
-  if (ipVersion === 6) {
-    return lower === '::1' || lower.startsWith('fc') || lower.startsWith('fd') || lower.startsWith('fe80');
-  }
-  return false;
-}
-
 function validateExternalUrl(rawUrl, source) {
-  let parsed;
   try {
-    parsed = new URL(rawUrl);
+    const parsed = normalizePublicHttpsUrl(rawUrl, { fieldPath: source });
+    parsed.hash = '';
+    return { ok: true, source, url: parsed.toString() };
   } catch (error) {
-    return { ok: false, source, url: rawUrl, category: 'invalid-url', detail: 'malformed URL' };
+    const detail = error?.message || 'invalid URL';
+    return {
+      ok: false,
+      source,
+      url: rawUrl,
+      category: detail.includes('malformed URL') ? 'invalid-url' : 'unsafe-url',
+      detail: detail.replace(/^Invalid [^:]+:\s*/, '')
+    };
   }
-
-  if (parsed.protocol !== 'https:') {
-    return { ok: false, source, url: rawUrl, category: 'unsafe-url', detail: 'only https URLs are checked' };
-  }
-  if (parsed.username || parsed.password) {
-    return { ok: false, source, url: rawUrl, category: 'unsafe-url', detail: 'credentials in URL are not allowed' };
-  }
-  if (isPrivateLiteralHost(parsed.hostname)) {
-    return { ok: false, source, url: rawUrl, category: 'unsafe-url', detail: 'local/private literal host is blocked' };
-  }
-
-  parsed.hash = '';
-  return { ok: true, source, url: parsed.toString() };
 }
 
 function collectJsonUrls(value, source, urls = []) {
@@ -150,11 +124,11 @@ function collectExternalUrls() {
     });
 }
 
-async function fetchWithTimeout(url, { method, timeoutMs }) {
+async function fetchWithTimeout(url, { method, timeoutMs, fetchImpl = fetch }) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    return await fetch(url, {
+    return await fetchImpl(url, {
       method,
       redirect: 'manual',
       signal: controller.signal,
@@ -172,9 +146,21 @@ async function checkUrl(entry, options) {
   if (!entry.ok) return entry;
 
   try {
-    let response = await fetchWithTimeout(entry.url, { method: 'HEAD', timeoutMs: options.timeoutMs });
+    const url = await assertPublicHttpsUrl(entry.url, {
+      fieldPath: entry.source,
+      lookupImpl: options.lookupImpl
+    });
+    let response = await fetchWithTimeout(url, {
+      method: 'HEAD',
+      timeoutMs: options.timeoutMs,
+      fetchImpl: options.fetchImpl
+    });
     if (response.status === 405 || response.status === 501) {
-      response = await fetchWithTimeout(entry.url, { method: 'GET', timeoutMs: options.timeoutMs });
+      response = await fetchWithTimeout(url, {
+        method: 'GET',
+        timeoutMs: options.timeoutMs,
+        fetchImpl: options.fetchImpl
+      });
     }
 
     const reachable = response.status >= 200 && response.status < 400;
@@ -189,7 +175,9 @@ async function checkUrl(entry, options) {
     return {
       ...entry,
       ok: false,
-      category: error?.name === 'AbortError' ? 'timeout' : 'network-error',
+      category: error?.message?.includes('blocked address') || error?.message?.includes('local/private')
+        ? 'unsafe-url'
+        : error?.name === 'AbortError' ? 'timeout' : 'network-error',
       detail: error?.message || 'network error'
     };
   }

--- a/scripts/check-vendor-governance.mjs
+++ b/scripts/check-vendor-governance.mjs
@@ -3,6 +3,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { ensureVendorHttpsUrl, ensureVendorUpstreamMatchesSource } from './lib/vendor-policy.mjs';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, '..');
@@ -73,21 +75,13 @@ function ensureVendorPath(rawPath, fieldPath) {
 
 function ensureHttpsUrl(rawUrl, fieldPath) {
   const value = ensureString(rawUrl, fieldPath);
-  let parsed;
   try {
-    parsed = new URL(value);
+    return ensureVendorHttpsUrl(value, fieldPath);
   } catch (error) {
-    fail(`Invalid manifest at ${fieldPath}: malformed URL`);
+    fail(error?.message?.startsWith('Invalid ')
+      ? error.message.replace(/^Invalid /, 'Invalid manifest at ')
+      : `Invalid manifest at ${fieldPath}: malformed URL`);
   }
-
-  if (parsed.protocol !== 'https:') {
-    fail(`Invalid manifest at ${fieldPath}: only https URLs are allowed`);
-  }
-  if (parsed.username || parsed.password) {
-    fail(`Invalid manifest at ${fieldPath}: credentials in URL are not allowed`);
-  }
-
-  return parsed.toString();
 }
 
 function parseIsoDate(rawDate, fieldPath) {
@@ -181,7 +175,7 @@ function validateVendorGovernance(manifest, options = {}) {
     ensureAllowedKeys(dependencyObject, fieldPath, ['name', 'registry_package', 'source', 'version', 'files']);
     ensureString(dependencyObject.name, `${fieldPath}.name`);
     ensureString(dependencyObject.registry_package, `${fieldPath}.registry_package`);
-    ensureString(dependencyObject.source, `${fieldPath}.source`);
+    const sourceUrl = ensureHttpsUrl(dependencyObject.source, `${fieldPath}.source`);
     ensureString(dependencyObject.version, `${fieldPath}.version`);
 
     ensureArray(dependencyObject.files, `${fieldPath}.files`).forEach((fileEntry, fileIndex) => {
@@ -190,7 +184,11 @@ function validateVendorGovernance(manifest, options = {}) {
       ensureAllowedKeys(fileObject, filePath, ['path', 'upstream_url', 'sha256', 'signatures']);
 
       const relativeFilePath = ensureVendorPath(fileObject.path, `${filePath}.path`);
-      ensureHttpsUrl(fileObject.upstream_url, `${filePath}.upstream_url`);
+      ensureVendorUpstreamMatchesSource(
+        ensureHttpsUrl(fileObject.upstream_url, `${filePath}.upstream_url`),
+        sourceUrl,
+        `${filePath}.upstream_url`
+      );
       const expectedSha = ensureString(fileObject.sha256, `${filePath}.sha256`).toLowerCase();
       if (!/^[0-9a-f]{64}$/.test(expectedSha)) {
         fail(`Invalid manifest at ${filePath}.sha256: expected 64 hex chars`);

--- a/scripts/lib/network-safety.mjs
+++ b/scripts/lib/network-safety.mjs
@@ -1,0 +1,228 @@
+import dns from 'node:dns/promises';
+import net from 'node:net';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function canonicalHostname(hostname) {
+  return hostname
+    .toLowerCase()
+    .replace(/^\[/, '')
+    .replace(/\]$/, '')
+    .replace(/\.$/, '');
+}
+
+function ipv4ToNumber(address) {
+  const parts = address.split('.');
+  if (parts.length !== 4) return null;
+
+  let value = 0;
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) return null;
+    const octet = Number.parseInt(part, 10);
+    if (octet < 0 || octet > 255) return null;
+    value = (value * 256) + octet;
+  }
+  return value >>> 0;
+}
+
+function ipv4Range(start, prefixLength) {
+  return {
+    start: ipv4ToNumber(start),
+    mask: prefixLength === 0 ? 0 : (0xffffffff << (32 - prefixLength)) >>> 0
+  };
+}
+
+const BLOCKED_IPV4_RANGES = [
+  ipv4Range('0.0.0.0', 8),
+  ipv4Range('10.0.0.0', 8),
+  ipv4Range('100.64.0.0', 10),
+  ipv4Range('127.0.0.0', 8),
+  ipv4Range('169.254.0.0', 16),
+  ipv4Range('172.16.0.0', 12),
+  ipv4Range('192.0.0.0', 24),
+  ipv4Range('192.0.2.0', 24),
+  ipv4Range('192.168.0.0', 16),
+  ipv4Range('198.18.0.0', 15),
+  ipv4Range('198.51.100.0', 24),
+  ipv4Range('203.0.113.0', 24),
+  ipv4Range('224.0.0.0', 4),
+  ipv4Range('240.0.0.0', 4)
+];
+
+function isBlockedIpv4Address(address) {
+  const value = ipv4ToNumber(address);
+  if (value === null) return false;
+  return BLOCKED_IPV4_RANGES.some((range) => (value & range.mask) === (range.start & range.mask));
+}
+
+function expandIpv4Tail(address) {
+  if (!address.includes('.')) return address;
+
+  const lastColon = address.lastIndexOf(':');
+  if (lastColon < 0) return address;
+
+  const ipv4 = address.slice(lastColon + 1);
+  const value = ipv4ToNumber(ipv4);
+  if (value === null) return address;
+
+  const high = ((value >>> 16) & 0xffff).toString(16);
+  const low = (value & 0xffff).toString(16);
+  return `${address.slice(0, lastColon)}:${high}:${low}`;
+}
+
+function parseIpv6Bytes(rawAddress) {
+  const address = expandIpv4Tail(canonicalHostname(rawAddress));
+  const parts = address.split('::');
+  if (parts.length > 2) return null;
+
+  const left = parts[0] ? parts[0].split(':') : [];
+  const right = parts.length === 2 && parts[1] ? parts[1].split(':') : [];
+  const missingGroups = 8 - left.length - right.length;
+
+  if ((parts.length === 1 && missingGroups !== 0) || missingGroups < 0) {
+    return null;
+  }
+
+  const groups = [
+    ...left,
+    ...Array.from({ length: parts.length === 2 ? missingGroups : 0 }, () => '0'),
+    ...right
+  ];
+
+  if (groups.length !== 8) return null;
+
+  const bytes = [];
+  for (const group of groups) {
+    if (!/^[0-9a-f]{1,4}$/i.test(group)) return null;
+    const value = Number.parseInt(group, 16);
+    bytes.push((value >>> 8) & 0xff, value & 0xff);
+  }
+  return bytes;
+}
+
+function bytesAreAll(bytes, value) {
+  return bytes.every((byte) => byte === value);
+}
+
+function bytesStartWith(bytes, prefix) {
+  return prefix.every((byte, index) => bytes[index] === byte);
+}
+
+function mappedIpv4FromIpv6Bytes(bytes) {
+  const isMapped = bytes.slice(0, 10).every((byte) => byte === 0) && bytes[10] === 0xff && bytes[11] === 0xff;
+  const isCompatible = bytes.slice(0, 12).every((byte) => byte === 0);
+  const isNat64WellKnown = bytesStartWith(bytes, [0x00, 0x64, 0xff, 0x9b]) && bytes.slice(4, 12).every((byte) => byte === 0);
+
+  if (!isMapped && !isCompatible && !isNat64WellKnown) return null;
+
+  return `${bytes[12]}.${bytes[13]}.${bytes[14]}.${bytes[15]}`;
+}
+
+function isBlockedIpv6Address(address) {
+  const bytes = parseIpv6Bytes(address);
+  if (!bytes) return false;
+
+  const mappedIpv4 = mappedIpv4FromIpv6Bytes(bytes);
+  if (mappedIpv4 && isBlockedIpv4Address(mappedIpv4)) return true;
+
+  return (
+    bytesAreAll(bytes, 0) ||
+    (bytes.slice(0, 15).every((byte) => byte === 0) && bytes[15] === 1) ||
+    ((bytes[0] & 0xfe) === 0xfc) ||
+    (bytes[0] === 0xfe && (bytes[1] & 0xc0) === 0x80) ||
+    bytes[0] === 0xff ||
+    bytesStartWith(bytes, [0x20, 0x01, 0x0d, 0xb8]) ||
+    bytesStartWith(bytes, [0x20, 0x01, 0x00, 0x00]) ||
+    bytesStartWith(bytes, [0x01, 0x00]) ||
+    bytesStartWith(bytes, [0x20, 0x02])
+  );
+}
+
+function isBlockedIpAddress(address) {
+  const canonical = canonicalHostname(address);
+  const ipVersion = net.isIP(canonical);
+  if (ipVersion === 4) return isBlockedIpv4Address(canonical);
+  if (ipVersion === 6) return isBlockedIpv6Address(canonical);
+  return false;
+}
+
+function isBlockedHostname(hostname) {
+  const canonical = canonicalHostname(hostname);
+  return canonical === 'localhost' || canonical.endsWith('.localhost');
+}
+
+function normalizePublicHttpsUrl(rawUrl, {
+  fieldPath = 'URL',
+  allowedHosts = null
+} = {}) {
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch (error) {
+    fail(`Invalid ${fieldPath}: malformed URL`);
+  }
+
+  if (parsed.protocol !== 'https:') {
+    fail(`Invalid ${fieldPath}: only https URLs are allowed`);
+  }
+  if (parsed.username || parsed.password) {
+    fail(`Invalid ${fieldPath}: credentials in URL are not allowed`);
+  }
+
+  const hostname = canonicalHostname(parsed.hostname);
+  if (isBlockedHostname(hostname)) {
+    fail(`Invalid ${fieldPath}: local/private host is blocked`);
+  }
+  if (isBlockedIpAddress(hostname)) {
+    fail(`Invalid ${fieldPath}: local/private IP address is blocked`);
+  }
+
+  if (allowedHosts) {
+    const allowed = new Set([...allowedHosts].map(canonicalHostname));
+    if (!allowed.has(hostname)) {
+      fail(`Invalid ${fieldPath}: host ${hostname} is not in the allowed upstream host list`);
+    }
+  }
+
+  return parsed;
+}
+
+async function resolveHostname(hostname, lookupImpl = dns.lookup) {
+  const records = await lookupImpl(hostname, { all: true, verbatim: true });
+  if (!Array.isArray(records) || records.length === 0) {
+    fail(`DNS lookup for ${hostname} returned no addresses`);
+  }
+  return records;
+}
+
+async function assertPublicDnsResolution(parsedUrl, {
+  fieldPath = 'URL',
+  lookupImpl = dns.lookup
+} = {}) {
+  const hostname = canonicalHostname(parsedUrl.hostname);
+  if (net.isIP(hostname)) return;
+
+  const records = await resolveHostname(hostname, lookupImpl);
+  const blockedRecord = records.find((record) => isBlockedIpAddress(record.address));
+  if (blockedRecord) {
+    fail(`Invalid ${fieldPath}: host ${hostname} resolved to blocked address ${blockedRecord.address}`);
+  }
+}
+
+async function assertPublicHttpsUrl(rawUrl, options = {}) {
+  const parsed = normalizePublicHttpsUrl(rawUrl, options);
+  await assertPublicDnsResolution(parsed, options);
+  return parsed.toString();
+}
+
+export {
+  assertPublicDnsResolution,
+  assertPublicHttpsUrl,
+  canonicalHostname,
+  isBlockedHostname,
+  isBlockedIpAddress,
+  normalizePublicHttpsUrl,
+  parseIpv6Bytes
+};

--- a/scripts/lib/vendor-policy.mjs
+++ b/scripts/lib/vendor-policy.mjs
@@ -1,0 +1,51 @@
+import {
+  assertPublicHttpsUrl,
+  canonicalHostname,
+  normalizePublicHttpsUrl
+} from './network-safety.mjs';
+
+const ALLOWED_VENDOR_UPSTREAM_HOSTS = new Set([
+  'storage.googleapis.com'
+]);
+
+function ensureVendorHttpsUrl(rawUrl, fieldPath) {
+  return normalizePublicHttpsUrl(rawUrl, {
+    fieldPath,
+    allowedHosts: ALLOWED_VENDOR_UPSTREAM_HOSTS
+  }).toString();
+}
+
+function ensureVendorUpstreamMatchesSource(upstreamUrl, sourceUrl, fieldPath) {
+  const upstream = normalizePublicHttpsUrl(upstreamUrl, {
+    fieldPath,
+    allowedHosts: ALLOWED_VENDOR_UPSTREAM_HOSTS
+  });
+  const source = normalizePublicHttpsUrl(sourceUrl, {
+    fieldPath: fieldPath.replace(/\.upstream_url$/, '.source'),
+    allowedHosts: ALLOWED_VENDOR_UPSTREAM_HOSTS
+  });
+
+  if (canonicalHostname(upstream.hostname) !== canonicalHostname(source.hostname)) {
+    throw new Error(`Invalid ${fieldPath}: upstream host must match dependency source host`);
+  }
+  if (!upstream.toString().startsWith(source.toString())) {
+    throw new Error(`Invalid ${fieldPath}: upstream URL must stay under dependency source ${source.toString()}`);
+  }
+
+  return upstream.toString();
+}
+
+async function assertPublicVendorUrl(rawUrl, fieldPath, options = {}) {
+  return await assertPublicHttpsUrl(rawUrl, {
+    ...options,
+    fieldPath,
+    allowedHosts: ALLOWED_VENDOR_UPSTREAM_HOSTS
+  });
+}
+
+export {
+  ALLOWED_VENDOR_UPSTREAM_HOSTS,
+  assertPublicVendorUrl,
+  ensureVendorHttpsUrl,
+  ensureVendorUpstreamMatchesSource
+};

--- a/scripts/update-vendor.mjs
+++ b/scripts/update-vendor.mjs
@@ -4,6 +4,11 @@ import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { loadManifest, validateVendorGovernance } from './check-vendor-governance.mjs';
+import {
+  assertPublicVendorUrl,
+  ensureVendorHttpsUrl,
+  ensureVendorUpstreamMatchesSource
+} from './lib/vendor-policy.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -55,21 +60,13 @@ function ensureVendorPath(rawPath, fieldPath) {
 
 function ensureHttpsUrl(rawUrl, fieldPath) {
   const urlString = ensureString(rawUrl, fieldPath);
-  let parsed;
   try {
-    parsed = new URL(urlString);
+    return ensureVendorHttpsUrl(urlString, fieldPath);
   } catch (error) {
-    fail(`Invalid manifest at ${fieldPath}: malformed URL`);
+    fail(error?.message?.startsWith('Invalid ')
+      ? error.message.replace(/^Invalid /, 'Invalid manifest at ')
+      : `Invalid manifest at ${fieldPath}: malformed URL`);
   }
-
-  if (parsed.protocol !== 'https:') {
-    fail(`Invalid manifest at ${fieldPath}: only https URLs are allowed`);
-  }
-  if (parsed.username || parsed.password) {
-    fail(`Invalid manifest at ${fieldPath}: credentials in URL are not allowed`);
-  }
-
-  return parsed.toString();
 }
 
 function parseArgs(argv = process.argv.slice(2)) {
@@ -120,6 +117,7 @@ function parseArgs(argv = process.argv.slice(2)) {
 function listManifestFiles(manifest) {
   return manifest.dependencies.flatMap((dependency, dependencyIndex) => {
     const dependencyObject = ensureObject(dependency, `manifest.dependencies[${dependencyIndex}]`);
+    const sourceUrl = ensureHttpsUrl(dependencyObject.source, `manifest.dependencies[${dependencyIndex}].source`);
     const files = dependencyObject.files;
     if (!Array.isArray(files) || files.length === 0) {
       fail(`Invalid manifest at manifest.dependencies[${dependencyIndex}].files: expected non-empty array`);
@@ -128,7 +126,11 @@ function listManifestFiles(manifest) {
     return files.map((fileEntry, fileIndex) => {
       const fieldPath = `manifest.dependencies[${dependencyIndex}].files[${fileIndex}]`;
       const fileObject = ensureObject(fileEntry, fieldPath);
-      const upstreamUrl = ensureHttpsUrl(fileObject.upstream_url, `${fieldPath}.upstream_url`);
+      const upstreamUrl = ensureVendorUpstreamMatchesSource(
+        ensureHttpsUrl(fileObject.upstream_url, `${fieldPath}.upstream_url`),
+        sourceUrl,
+        `${fieldPath}.upstream_url`
+      );
       const relativePath = ensureVendorPath(fileObject.path, `${fieldPath}.path`);
       const signatures = Array.isArray(fileObject.signatures) ? fileObject.signatures.map((signature, signatureIndex) =>
         ensureString(signature, `${fieldPath}.signatures[${signatureIndex}]`)
@@ -173,7 +175,10 @@ async function fetchVendorFiles(manifest, options = {}) {
   const results = [];
 
   for (const fileEntry of files) {
-    const response = await fetchWithTimeout(fileEntry.upstreamUrl, options);
+    const safeUrl = await assertPublicVendorUrl(fileEntry.upstreamUrl, `manifest.dependencies[${fileEntry.dependencyIndex}].files[${fileEntry.fileIndex}].upstream_url`, {
+      lookupImpl: options.lookupImpl
+    });
+    const response = await fetchWithTimeout(safeUrl, options);
     if (!response.ok) {
       fail(`Failed to fetch ${fileEntry.upstreamUrl}: ${response.status} ${response.statusText}`);
     }
@@ -256,6 +261,7 @@ async function runVendorRefresh(options = {}, dependencies = {}) {
 
   const fetchedFiles = await fetchVendorFiles(manifest, {
     fetchImpl: dependencies.fetchImpl || fetch,
+    lookupImpl: dependencies.lookupImpl,
     timeoutMs: options.timeoutMs
   });
 

--- a/tests/security/ops-scripts.test.mjs
+++ b/tests/security/ops-scripts.test.mjs
@@ -82,6 +82,48 @@ test('link health validator rejects unsafe URL shapes before network access', as
   assert.equal(validateExternalUrl('https://user:pass@example.com', 'fixture').ok, false);
   assert.equal(validateExternalUrl('https://localhost/status', 'fixture').ok, false);
   assert.equal(validateExternalUrl('https://127.0.0.1/status', 'fixture').ok, false);
+  assert.equal(validateExternalUrl('https://[::1]/status', 'fixture').ok, false);
+  assert.equal(validateExternalUrl('https://[fd00::1]/status', 'fixture').ok, false);
   assert.equal(validateExternalUrl('https://192.168.0.10/status', 'fixture').ok, false);
   assert.equal(validateExternalUrl('notaurl', 'fixture').category, 'invalid-url');
+});
+
+test('network safety rejects private and reserved DNS answers before fetch', async () => {
+  const {
+    assertPublicHttpsUrl,
+    isBlockedIpAddress
+  } = await import('../../scripts/lib/network-safety.mjs');
+
+  assert.equal(isBlockedIpAddress('10.0.0.1'), true);
+  assert.equal(isBlockedIpAddress('100.64.0.1'), true);
+  assert.equal(isBlockedIpAddress('169.254.169.254'), true);
+  assert.equal(isBlockedIpAddress('198.51.100.10'), true);
+  assert.equal(isBlockedIpAddress('8.8.8.8'), false);
+  assert.equal(isBlockedIpAddress('::ffff:127.0.0.1'), true);
+  assert.equal(isBlockedIpAddress('2001:db8::1'), true);
+  assert.equal(isBlockedIpAddress('2606:4700:4700::1111'), false);
+
+  await assert.rejects(
+    () => assertPublicHttpsUrl('https://private.example/status', {
+      lookupImpl: async () => [{ address: '10.0.0.5', family: 4 }]
+    }),
+    /resolved to blocked address 10\.0\.0\.5/
+  );
+
+  await assert.rejects(
+    () => assertPublicHttpsUrl('https://mixed.example/status', {
+      lookupImpl: async () => [
+        { address: '93.184.216.34', family: 4 },
+        { address: 'fd00::1', family: 6 }
+      ]
+    }),
+    /resolved to blocked address fd00::1/
+  );
+
+  assert.equal(
+    await assertPublicHttpsUrl('https://public.example/status', {
+      lookupImpl: async () => [{ address: '93.184.216.34', family: 4 }]
+    }),
+    'https://public.example/status'
+  );
 });

--- a/tests/security/policy-regression.test.mjs
+++ b/tests/security/policy-regression.test.mjs
@@ -53,6 +53,30 @@ test('workflow uses references are pinned by SHA', () => {
   assert.deepEqual(unpinned, [], `Found unpinned action references:\n${unpinned.join('\n')}`);
 });
 
+test('workflow npm installs disable dependency lifecycle scripts', () => {
+  const unsafeInstalls = [];
+
+  for (const file of WORKFLOW_FILES) {
+    const content = fs.readFileSync(file, 'utf8');
+    const lines = content.split('\n');
+    lines.forEach((line, index) => {
+      if (/\brun:\s*npm ci\b/.test(line) && !line.includes('--ignore-scripts')) {
+        unsafeInstalls.push(`${file}:${index + 1}:${line.trim()}`);
+      }
+    });
+  }
+
+  assert.deepEqual(unsafeInstalls, [], `Found npm ci without --ignore-scripts:\n${unsafeInstalls.join('\n')}`);
+});
+
+test('scan workflow enforces dependency audit and vendor governance gates', () => {
+  const content = fs.readFileSync('.github/workflows/scan.yml', 'utf8');
+
+  assert.match(content, /npm run audit:high/);
+  assert.match(content, /npm run validate:vendor:governance/);
+  assert.doesNotMatch(content, /npm run validate:vendor(?:\s|$)/);
+});
+
 test('Gemini workflow separates planning from write-capable execution', () => {
   const content = fs.readFileSync('.github/workflows/gemini-cli.yml', 'utf8');
   const planJobStart = content.indexOf('  gemini-cli-plan:');
@@ -140,6 +164,17 @@ test('_headers includes required runtime security headers', () => {
   assert.match(content, /X-Frame-Options:\s*DENY/i);
   assert.match(content, /X-Content-Type-Options:\s*nosniff/i);
   assert.match(content, /Referrer-Policy:\s*strict-origin-when-cross-origin/i);
+});
+
+test('CSP monitoring fallback and rollout requirements are documented', () => {
+  const monitoring = fs.readFileSync('docs/security/csp-monitoring.md', 'utf8');
+  const deploymentHeaders = fs.readFileSync('docs/security/deployment-headers.md', 'utf8');
+
+  assert.match(monitoring, /no committed\s+CSP report collector endpoint/i);
+  assert.match(monitoring, /No `report-uri` or `report-to` directive should be added without a real,\s+approved HTTPS collector endpoint\./i);
+  assert.match(monitoring, /Cloudflare security events/i);
+  assert.match(monitoring, /Collector Rollout Requirements/);
+  assert.match(deploymentHeaders, /docs\/security\/csp-monitoring\.md/);
 });
 
 test('target=_blank always includes noopener and noreferrer', () => {

--- a/tests/security/vendor-refresh.test.mjs
+++ b/tests/security/vendor-refresh.test.mjs
@@ -13,6 +13,10 @@ import {
   updateManifestHashes
 } from '../../scripts/update-vendor.mjs';
 
+async function publicLookup() {
+  return [{ address: '142.250.190.27', family: 4 }];
+}
+
 function makeManifest() {
   return {
     last_reviewed: '2026-04-08',
@@ -43,6 +47,7 @@ test('ensureHttpsUrl rejects non-https upstream URLs', () => {
     'https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js'
   );
   assert.throws(() => ensureHttpsUrl('http://example.com/file.js', 'file.upstream_url'), /only https URLs are allowed/);
+  assert.throws(() => ensureHttpsUrl('https://example.com/file.js', 'file.upstream_url'), /not in the allowed upstream host list/);
 });
 
 test('parseArgs defaults to dry-run and validates known flags', () => {
@@ -71,6 +76,7 @@ test('fetchVendorFiles downloads upstream content and verifies signatures', asyn
   const payload = '/* workbox:test:9.9.9 */\nconsole.log("test-file.js");\n';
   const fetched = await fetchVendorFiles(manifest, {
     fetchImpl: async () => new Response(payload, { status: 200 }),
+    lookupImpl: publicLookup,
     timeoutMs: 5000
   });
 
@@ -85,9 +91,43 @@ test('fetchVendorFiles rejects upstream payloads that miss required signatures',
   await assert.rejects(
     () => fetchVendorFiles(manifest, {
       fetchImpl: async () => new Response('console.log("wrong");', { status: 200 }),
+      lookupImpl: publicLookup,
       timeoutMs: 5000
     }),
     /missing signature/
+  );
+});
+
+test('fetchVendorFiles rejects private DNS answers before fetching upstream content', async () => {
+  const manifest = makeManifest();
+  let fetched = false;
+
+  await assert.rejects(
+    () => fetchVendorFiles(manifest, {
+      fetchImpl: async () => {
+        fetched = true;
+        return new Response('/* workbox:test:9.9.9 */', { status: 200 });
+      },
+      lookupImpl: async () => [{ address: '192.168.1.10', family: 4 }],
+      timeoutMs: 5000
+    }),
+    /resolved to blocked address 192\.168\.1\.10/
+  );
+
+  assert.equal(fetched, false);
+});
+
+test('fetchVendorFiles rejects upstream URLs outside the dependency source', async () => {
+  const manifest = makeManifest();
+  manifest.dependencies[0].files[0].upstream_url = 'https://storage.googleapis.com/other-bucket/test-file.js';
+
+  await assert.rejects(
+    () => fetchVendorFiles(manifest, {
+      fetchImpl: async () => new Response('/* workbox:test:9.9.9 */', { status: 200 }),
+      lookupImpl: publicLookup,
+      timeoutMs: 5000
+    }),
+    /upstream URL must stay under dependency source/
   );
 });
 
@@ -106,16 +146,22 @@ test('updateManifestHashes and runVendorRefresh write deterministic outputs', as
   );
 
   const payload = '/* workbox:test:9.9.9 */\nconsole.log("test-file.js");\n';
+  let lookupCalls = 0;
   const result = await runVendorRefresh(
     { write: true, timeoutMs: 5000, today: '2026-04-09' },
     {
       rootDir: tempRoot,
       manifestPath,
-      fetchImpl: async () => new Response(payload, { status: 200 })
+      fetchImpl: async () => new Response(payload, { status: 200 }),
+      lookupImpl: async (...args) => {
+        lookupCalls += 1;
+        return publicLookup(...args);
+      }
     }
   );
 
   assert.equal(result.write, true);
+  assert.equal(lookupCalls, 1);
   assert.equal(result.summary[0].changed, true);
   assert.equal(JSON.parse(fs.readFileSync(manifestPath, 'utf8')).last_reviewed, '2026-04-09');
   assert.equal(fs.readFileSync(path.join(vendorDir, 'test-file.js'), 'utf8'), payload);


### PR DESCRIPTION
## Summary

Hardens ProjectPortfolio static validation, vendor refresh, and CI security gates after the 2026-05-28 security assessment. The branch adds DNS/private-address preflight checks for repo-maintained network scripts, enforces vendor source/upstream policy, and documents the remaining DNS preflight limitation explicitly.

## Changes

- Added shared network safety helpers for HTTPS URL normalization, DNS resolution checks, and private-address blocking.
- Applied network preflight checks to link health and vendor refresh scripts.
- Added vendor policy checks for dependency source/upstream matching and split CI vendor validation into governance and upstream gates.
- Disabled dependency lifecycle scripts in the Playwright integration workflow install step.
- Made Playwright integration port explicit and disabled reuse of unrelated local servers.
- Added CSP monitoring and remediation-status documentation for the security assessment.
- Added regression coverage for blocked private targets, vendor policy enforcement, and injected DNS lookup paths.

## Testing

- `git diff --staged --check` - passed
- `node --test tests/security/vendor-refresh.test.mjs tests/security/ops-scripts.test.mjs tests/security/policy-regression.test.mjs` - passed, 29/29
- `PLAYWRIGHT_PORT=4174 npm run validate:full` - passed

Note: the default local port `4173` was already occupied by an unrelated local Node server during validation, so the full gate was run on `4174`. The Playwright config now supports this explicitly and does not silently reuse a wrong server.

## Risk

Risk is moderate because this changes release validation and maintainer-side fetch behavior. The hardening is conservative: non-public DNS answers, unsupported URL schemes, path traversal, and mismatched vendor sources fail closed. The DNS preflight remains a best-effort control because the subsequent fetch still resolves the hostname again; this limitation is documented.

## Rollback Plan

Revert this PR if release validation or vendor refresh behavior blocks legitimate maintenance work unexpectedly. No data migration or production runtime change is required.

## Notes for Reviewers

Please review `scripts/lib/network-safety.mjs`, `scripts/update-vendor.mjs`, and `scripts/check-vendor-governance.mjs` for the maintainer-side security boundary and documented DNS preflight tradeoff.