### PR TITLE
ci: add portfolio validation gates

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,29 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # ratchet:actions/dependency-review-action@v5.0.0
+        with:
+          fail-on-severity: high
+          license-check: true

--- a/.github/workflows/link-health.yml
+++ b/.github/workflows/link-health.yml
@@ -1,0 +1,35 @@
+name: Link Health
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '12 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  link-health:
+    name: Live Link Health
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build generated pages
+        run: npm run build
+
+      - name: Check live external links
+        run: npm run check:links -- --strict --timeout-ms 8000

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,0 +1,39 @@
+name: Production Smoke
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '42 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  production-smoke:
+    name: Production Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Check production pages and headers
+        run: npm run check:production
+        env:
+          SMOKE_ATTEMPTS: '6'
+          SMOKE_RETRY_DELAY_MS: '10000'
+          SMOKE_TIMEOUT_MS: '10000'

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,39 @@
+name: Release Candidate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  release-candidate:
+    name: Full Validation
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: release-candidate-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install Chromium for Playwright
+        run: ./node_modules/.bin/playwright install --with-deps chromium
+
+      - name: Run full validation
+        run: npm run validate:full

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Install Node dependencies
         run: npm ci --ignore-scripts
 
+      - name: Check repository hygiene
+        run: npm run check:hygiene
+
+      - name: Check workflow hygiene
+        run: npm run check:workflows
+
       - name: Build generated pages
         run: npm run build
 
@@ -38,6 +44,9 @@ jobs:
 
       - name: Run security and content tests
         run: npm run test:security
+
+      - name: Run PR-safe link preflight
+        run: npm run check:links:preflight
 
       - name: Run high severity dependency audit
         run: npm run audit:high

--- a/css/custom.css
+++ b/css/custom.css
@@ -9,6 +9,8 @@
   --border-strong: rgba(32, 24, 18, 0.22);
   --accent: #d3572f;
   --accent-strong: #b84725;
+  --accent-button: #b84725;
+  --accent-button-hover: #9f3a1e;
   --accent-cool: #2b6f68;
   --accent-soft: rgba(211, 87, 47, 0.14);
   --grid: rgba(210, 168, 115, 0.2);
@@ -39,6 +41,8 @@
   --border-strong: rgba(242, 239, 233, 0.25);
   --accent: #f08a5d;
   --accent-strong: #e06a40;
+  --accent-button: #b84725;
+  --accent-button-hover: #9f3a1e;
   --accent-cool: #74b7ad;
   --accent-soft: rgba(240, 138, 93, 0.18);
   --grid: rgba(240, 138, 93, 0.15);
@@ -64,6 +68,8 @@
     --border-strong: rgba(242, 239, 233, 0.25);
     --accent: #f08a5d;
     --accent-strong: #e06a40;
+    --accent-button: #b84725;
+    --accent-button-hover: #9f3a1e;
     --accent-cool: #74b7ad;
     --accent-soft: rgba(240, 138, 93, 0.18);
     --grid: rgba(240, 138, 93, 0.15);
@@ -1228,16 +1234,16 @@ footer {
 }
 
 .btn-primary {
-  background: var(--accent);
-  border-color: var(--accent);
+  background: var(--accent-button);
+  border-color: var(--accent-button);
   color: #fff;
   box-shadow: 0 16px 30px -20px rgba(211, 87, 47, 0.6);
 }
 
 .btn-primary:hover,
 .btn-primary:focus {
-  background: var(--accent-strong);
-  border-color: var(--accent-strong);
+  background: var(--accent-button-hover);
+  border-color: var(--accent-button-hover);
   color: #fff;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,25 @@
       "name": "projectportfolio",
       "version": "0.0.0",
       "devDependencies": {
-        "@playwright/test": "1.60.0"
+        "@axe-core/playwright": "^4.11.3",
+        "@playwright/test": "1.60.0",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -28,6 +43,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/fsevents": {
@@ -75,6 +100,22 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,19 +14,25 @@
     "test:integration": "npx --no-install playwright test tests/integration/mobile-nav-and-accordion.spec.mjs --config=playwright.config.mjs",
     "audit:high": "npm audit --audit-level=high",
     "check:generated": "git diff --exit-code -- index.html reading.html offline.html _headers",
+    "check:hygiene": "node scripts/check-repository-hygiene.mjs",
     "check:assets": "node scripts/check-performance-budget.mjs",
+    "check:accessibility": "npx --no-install playwright test tests/integration/accessibility-smoke.spec.mjs --config=playwright.config.mjs",
     "check:links": "node scripts/check-link-health.mjs",
     "check:links:preflight": "node scripts/check-link-health.mjs --preflight-only --strict",
     "check:performance": "node scripts/check-performance-budget.mjs",
+    "check:production": "node scripts/check-production-smoke.mjs",
     "check:reading": "node scripts/audit-reading-metadata.mjs",
     "check:telemetry": "node scripts/check-telemetry-policy.mjs",
+    "check:workflows": "node scripts/check-workflow-hygiene.mjs",
     "validate:vendor:governance": "node scripts/check-vendor-governance.mjs",
     "validate:vendor:upstream": "node scripts/update-vendor.mjs && node scripts/check-vendor-upstream.mjs",
     "validate:vendor": "npm run validate:vendor:governance && npm run validate:vendor:upstream",
     "validate": "npm run build && npm run test:security",
-    "validate:full": "npm run build && npm run check:generated && npm run test:security && npm run check:reading && npm run check:performance && npm run check:telemetry && npm run audit:high && npm run validate:vendor && npm run test:integration"
+    "validate:full": "npm run build && npm run check:generated && npm run check:hygiene && npm run check:workflows && npm run test:security && npm run check:reading && npm run check:performance && npm run check:telemetry && npm run check:links:preflight && npm run audit:high && npm run validate:vendor && npm run test:integration && npm run check:accessibility"
   },
   "devDependencies": {
-    "@playwright/test": "1.60.0"
+    "@axe-core/playwright": "^4.11.3",
+    "@playwright/test": "1.60.0",
+    "yaml": "^2.9.0"
   }
 }

--- a/scripts/check-production-smoke.mjs
+++ b/scripts/check-production-smoke.mjs
@@ -1,0 +1,173 @@
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_ORIGIN = 'https://leonardwong.tech';
+const DEFAULT_TIMEOUT_MS = 10000;
+const DEFAULT_ATTEMPTS = 6;
+const DEFAULT_RETRY_DELAY_MS = 10000;
+
+const PAGE_CHECKS = [
+  {
+    path: '/',
+    marker: /Leonard Wong/i,
+    headers: [
+      'content-security-policy',
+      'strict-transport-security',
+      'x-content-type-options'
+    ]
+  },
+  {
+    path: '/reading',
+    marker: /Reading/i,
+    headers: [
+      'content-security-policy',
+      'x-content-type-options'
+    ]
+  },
+  {
+    path: '/offline',
+    marker: /Offline/i,
+    headers: [
+      'content-security-policy',
+      'x-content-type-options'
+    ]
+  }
+];
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    origin: process.env.SITE_ORIGIN || DEFAULT_ORIGIN,
+    timeoutMs: Number.parseInt(process.env.SMOKE_TIMEOUT_MS || `${DEFAULT_TIMEOUT_MS}`, 10),
+    attempts: Number.parseInt(process.env.SMOKE_ATTEMPTS || `${DEFAULT_ATTEMPTS}`, 10),
+    retryDelayMs: Number.parseInt(process.env.SMOKE_RETRY_DELAY_MS || `${DEFAULT_RETRY_DELAY_MS}`, 10)
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--origin') {
+      options.origin = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--timeout-ms') {
+      options.timeoutMs = Number.parseInt(argv[index + 1], 10);
+      index += 1;
+      continue;
+    }
+    if (arg === '--attempts') {
+      options.attempts = Number.parseInt(argv[index + 1], 10);
+      index += 1;
+      continue;
+    }
+    if (arg === '--retry-delay-ms') {
+      options.retryDelayMs = Number.parseInt(argv[index + 1], 10);
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!options.origin.startsWith('https://')) {
+    throw new Error('Production smoke origin must be an HTTPS URL');
+  }
+
+  return options;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function fetchTextWithTimeout(url, { fetchImpl = fetch, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: {
+        'user-agent': 'ProjectPortfolio-production-smoke/1.0'
+      }
+    });
+    const body = await response.text();
+    return { response, body };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function validatePage({ url, response, body, check }) {
+  const findings = [];
+
+  if (response.status !== 200) {
+    findings.push(`${url}: expected HTTP 200, received ${response.status}`);
+  }
+
+  check.headers.forEach((header) => {
+    if (!response.headers.get(header)) {
+      findings.push(`${url}: missing ${header} header`);
+    }
+  });
+
+  if (response.headers.get('x-content-type-options')?.toLowerCase() !== 'nosniff') {
+    findings.push(`${url}: x-content-type-options must be nosniff`);
+  }
+
+  if (!check.marker.test(body)) {
+    findings.push(`${url}: expected page marker was not found`);
+  }
+
+  return findings;
+}
+
+async function runProductionSmoke(options = parseArgs()) {
+  let lastFindings = [];
+
+  for (let attempt = 1; attempt <= options.attempts; attempt += 1) {
+    const findings = [];
+
+    for (const check of PAGE_CHECKS) {
+      const url = new URL(check.path, options.origin).toString();
+      try {
+        const result = await fetchTextWithTimeout(url, options);
+        findings.push(...validatePage({ url, check, ...result }));
+      } catch (error) {
+        findings.push(`${url}: ${error?.message || 'request failed'}`);
+      }
+    }
+
+    if (findings.length === 0) {
+      return [];
+    }
+
+    lastFindings = findings;
+    if (attempt < options.attempts) {
+      await sleep(options.retryDelayMs);
+    }
+  }
+
+  return lastFindings;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const findings = await runProductionSmoke();
+    if (findings.length > 0) {
+      console.error('Production smoke check failed:');
+      findings.forEach((finding) => console.error(`- ${finding}`));
+      process.exit(1);
+    }
+    console.log('Production smoke check passed.');
+  } catch (error) {
+    console.error(error?.message || 'Production smoke check failed.');
+    process.exit(1);
+  }
+}
+
+export {
+  PAGE_CHECKS,
+  parseArgs,
+  runProductionSmoke,
+  validatePage
+};

--- a/scripts/check-repository-hygiene.mjs
+++ b/scripts/check-repository-hygiene.mjs
@@ -1,0 +1,98 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const JUNK_FILE_NAMES = new Set([
+  '.DS_Store',
+  'Thumbs.db',
+  'ehthumbs.db',
+  'Desktop.ini',
+  'npm-debug.log',
+  'yarn-debug.log',
+  'yarn-error.log',
+  'pnpm-debug.log'
+]);
+
+const JUNK_PATH_SEGMENTS = new Set([
+  '__MACOSX'
+]);
+
+const JUNK_EXTENSIONS = [
+  '.log',
+  '.orig',
+  '.rej',
+  '.swo',
+  '.swp',
+  '.tmp'
+];
+
+function listGitVisibleFiles({ cwd = process.cwd() } = {}) {
+  const output = execFileSync('git', [
+    'ls-files',
+    '--cached',
+    '--others',
+    '--exclude-standard',
+    '-z'
+  ], {
+    cwd,
+    encoding: 'utf8'
+  });
+
+  return output
+    .split('\0')
+    .filter(Boolean)
+    .sort();
+}
+
+function isJunkPath(filePath) {
+  const normalizedPath = filePath.replaceAll(path.sep, '/');
+  const segments = normalizedPath.split('/');
+  const baseName = segments.at(-1);
+  const lowerBaseName = baseName.toLowerCase();
+
+  if (JUNK_FILE_NAMES.has(baseName) || JUNK_FILE_NAMES.has(lowerBaseName)) {
+    return true;
+  }
+
+  if (segments.some((segment) => JUNK_PATH_SEGMENTS.has(segment))) {
+    return true;
+  }
+
+  if (baseName.endsWith('~') || baseName.endsWith('.icloud')) {
+    return true;
+  }
+
+  return JUNK_EXTENSIONS.some((extension) => lowerBaseName.endsWith(extension));
+}
+
+function collectRepositoryHygieneFindings({ cwd = process.cwd() } = {}) {
+  return listGitVisibleFiles({ cwd }).filter(isJunkPath);
+}
+
+function formatFindings(findings) {
+  return [
+    'Repository hygiene check failed. Remove or ignore these generated/local files:',
+    ...findings.map((finding) => `- ${finding}`)
+  ].join('\n');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const findings = collectRepositoryHygieneFindings();
+    if (findings.length > 0) {
+      console.error(formatFindings(findings));
+      process.exit(1);
+    }
+    console.log('Repository hygiene check passed.');
+  } catch (error) {
+    console.error(error?.message || 'Repository hygiene check failed.');
+    process.exit(1);
+  }
+}
+
+export {
+  collectRepositoryHygieneFindings,
+  formatFindings,
+  isJunkPath,
+  listGitVisibleFiles
+};

--- a/scripts/check-workflow-hygiene.mjs
+++ b/scripts/check-workflow-hygiene.mjs
@@ -1,0 +1,156 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import YAML from 'yaml';
+
+const WORKFLOW_DIR = '.github/workflows';
+const REMOTE_ACTION_WITH_SHA = /^['"]?([^@\s'"]+)@([0-9a-f]{40})['"]?$/i;
+const RATchet_COMMENT = /#\s*ratchet:([^@\s]+)@([^\s]+)/;
+const BODY_INTERPOLATION_PATTERN = /\$\{\{\s*github\.event\.(?:issue|comment|review|pull_request)\.body\s*}}/;
+
+function listWorkflowFiles({ cwd = process.cwd() } = {}) {
+  return fs.readdirSync(path.join(cwd, WORKFLOW_DIR))
+    .filter((file) => file.endsWith('.yml') || file.endsWith('.yaml'))
+    .map((file) => `${WORKFLOW_DIR}/${file}`)
+    .sort();
+}
+
+function parseWorkflowYaml(filePath, content, findings) {
+  const document = YAML.parseDocument(content, {
+    prettyErrors: false,
+    strict: true
+  });
+
+  if (document.errors.length > 0) {
+    findings.push(...document.errors.map((error) => `${filePath}: invalid YAML: ${error.message}`));
+    return null;
+  }
+
+  return document.toJSON();
+}
+
+function validateUsesLine(filePath, line, lineNumber, findings) {
+  const match = line.match(/\buses:\s*(\S+)/);
+  if (!match) return;
+
+  const rawReference = match[1].replace(/^['"]|['"]$/g, '');
+  if (rawReference.startsWith('./') || rawReference.startsWith('docker://')) {
+    return;
+  }
+
+  const remoteMatch = rawReference.match(REMOTE_ACTION_WITH_SHA);
+  if (!remoteMatch) {
+    findings.push(`${filePath}:${lineNumber}: action reference is not pinned to a full SHA: ${line.trim()}`);
+    return;
+  }
+
+  const commentMatch = line.match(RATchet_COMMENT);
+  if (!commentMatch) {
+    findings.push(`${filePath}:${lineNumber}: pinned action is missing a ratchet comment: ${line.trim()}`);
+    return;
+  }
+
+  const [, actionPath] = remoteMatch;
+  const [, ratchetPath, ratchetVersion] = commentMatch;
+  if (!actionPath.startsWith(ratchetPath)) {
+    findings.push(`${filePath}:${lineNumber}: ratchet comment path does not match action path: ${line.trim()}`);
+  }
+  if (!/^v?\d+(?:\.\d+){0,2}$/.test(ratchetVersion)) {
+    findings.push(`${filePath}:${lineNumber}: ratchet comment must name a version tag, not a branch or SHA: ${line.trim()}`);
+  }
+}
+
+function validateRunBlocks(filePath, lines, findings) {
+  let activeRunBlock = null;
+
+  lines.forEach((line, index) => {
+    const lineNumber = index + 1;
+    const runMatch = line.match(/^(\s*)run:\s*(.*)$/);
+
+    if (runMatch) {
+      activeRunBlock = {
+        indent: runMatch[1].length,
+        startLine: lineNumber
+      };
+
+      const inlineCommand = runMatch[2];
+      if (/\bnpm ci\b/.test(inlineCommand) && !inlineCommand.includes('--ignore-scripts')) {
+        findings.push(`${filePath}:${lineNumber}: npm ci must use --ignore-scripts`);
+      }
+      if (BODY_INTERPOLATION_PATTERN.test(inlineCommand)) {
+        findings.push(`${filePath}:${lineNumber}: do not interpolate PR/comment body content directly into shell commands`);
+      }
+      return;
+    }
+
+    if (!activeRunBlock) return;
+
+    const indent = line.match(/^(\s*)/)[1].length;
+    if (line.trim() && indent <= activeRunBlock.indent) {
+      activeRunBlock = null;
+      return;
+    }
+
+    if (/\bnpm ci\b/.test(line) && !line.includes('--ignore-scripts')) {
+      findings.push(`${filePath}:${lineNumber}: npm ci must use --ignore-scripts`);
+    }
+    if (BODY_INTERPOLATION_PATTERN.test(line)) {
+      findings.push(`${filePath}:${lineNumber}: do not interpolate PR/comment body content directly into shell commands`);
+    }
+  });
+}
+
+function collectWorkflowHygieneFindings({ cwd = process.cwd() } = {}) {
+  const findings = [];
+  const workflowFiles = listWorkflowFiles({ cwd });
+
+  workflowFiles.forEach((filePath) => {
+    const absolutePath = path.join(cwd, filePath);
+    const content = fs.readFileSync(absolutePath, 'utf8');
+    const lines = content.split('\n');
+    const workflow = parseWorkflowYaml(filePath, content, findings);
+
+    if (content.includes('pull_request_target:')) {
+      findings.push(`${filePath}: pull_request_target is not allowed without an explicit review exception`);
+    }
+
+    if (workflow && !Object.hasOwn(workflow, 'permissions')) {
+      findings.push(`${filePath}: missing top-level permissions block`);
+    }
+
+    lines.forEach((line, index) => {
+      validateUsesLine(filePath, line, index + 1, findings);
+    });
+
+    validateRunBlocks(filePath, lines, findings);
+  });
+
+  return findings.sort();
+}
+
+function formatFindings(findings) {
+  return [
+    'Workflow hygiene check failed:',
+    ...findings.map((finding) => `- ${finding}`)
+  ].join('\n');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const findings = collectWorkflowHygieneFindings();
+    if (findings.length > 0) {
+      console.error(formatFindings(findings));
+      process.exit(1);
+    }
+    console.log('Workflow hygiene check passed.');
+  } catch (error) {
+    console.error(error?.message || 'Workflow hygiene check failed.');
+    process.exit(1);
+  }
+}
+
+export {
+  collectWorkflowHygieneFindings,
+  formatFindings,
+  listWorkflowFiles
+};

--- a/tests/integration/accessibility-smoke.spec.mjs
+++ b/tests/integration/accessibility-smoke.spec.mjs
@@ -1,0 +1,26 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+const PAGE_PATHS = [
+  '/index.html',
+  '/reading.html',
+  '/offline.html'
+];
+
+test.describe('accessibility smoke', () => {
+  for (const pagePath of PAGE_PATHS) {
+    test(`${pagePath} has no serious or critical axe violations`, async ({ page }) => {
+      await page.goto(pagePath);
+
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        .analyze();
+
+      const blockingViolations = results.violations.filter((violation) => (
+        violation.impact === 'serious' || violation.impact === 'critical'
+      ));
+
+      expect(blockingViolations).toEqual([]);
+    });
+  }
+});

--- a/tests/security/ops-scripts.test.mjs
+++ b/tests/security/ops-scripts.test.mjs
@@ -150,6 +150,53 @@ test('link health preflight mode validates DNS without fetching URLs', async () 
   assert.ok(results.some((result) => result.category === 'preflight-ok'));
 });
 
+test('repository hygiene detects junk files in git-visible paths', async () => {
+  const { isJunkPath } = await import('../../scripts/check-repository-hygiene.mjs');
+
+  assert.equal(isJunkPath('.github/workflows/.DS_Store'), true);
+  assert.equal(isJunkPath('notes/debug.log'), true);
+  assert.equal(isJunkPath('src/index.html'), false);
+});
+
+test('workflow hygiene enforces pinned actions and safe npm installs', async () => {
+  const { collectWorkflowHygieneFindings } = await import('../../scripts/check-workflow-hygiene.mjs');
+
+  assert.deepEqual(collectWorkflowHygieneFindings(), []);
+});
+
+test('production smoke validator reports missing headers and markers', async () => {
+  const { validatePage } = await import('../../scripts/check-production-smoke.mjs');
+  const headers = new Headers({
+    'content-security-policy': "default-src 'self'",
+    'x-content-type-options': 'nosniff'
+  });
+
+  assert.deepEqual(
+    validatePage({
+      url: 'https://example.test/reading',
+      response: { status: 200, headers },
+      body: '<h1>Reading</h1>',
+      check: {
+        marker: /Reading/i,
+        headers: ['content-security-policy', 'x-content-type-options']
+      }
+    }),
+    []
+  );
+
+  assert.ok(
+    validatePage({
+      url: 'https://example.test/offline',
+      response: { status: 200, headers: new Headers() },
+      body: '<h1>Unexpected</h1>',
+      check: {
+        marker: /Offline/i,
+        headers: ['content-security-policy', 'x-content-type-options']
+      }
+    }).length > 0
+  );
+});
+
 test('telemetry policy check rejects external runtime analytics adapters', async () => {
   const { collectTelemetryPolicyFindings } = await import('../../scripts/check-telemetry-policy.mjs');
 

--- a/tests/security/policy-regression.test.mjs
+++ b/tests/security/policy-regression.test.mjs
@@ -30,8 +30,12 @@ test('workflow uses references are pinned by SHA', () => {
   assert.deepEqual(WORKFLOW_FILES, [
     '.github/workflows/build.yml',
     '.github/workflows/codeql.yml',
+    '.github/workflows/dependency-review.yml',
     '.github/workflows/gemini-cli.yml',
+    '.github/workflows/link-health.yml',
     '.github/workflows/playwright-integration.yml',
+    '.github/workflows/production-smoke.yml',
+    '.github/workflows/release-candidate.yml',
     '.github/workflows/scan.yml',
     '.github/workflows/vendor-review.yml'
   ]);


### PR DESCRIPTION
## Summary

Adds deterministic CI gates for repository hygiene, workflow hygiene, PR-safe link preflight, dependency review, release-candidate validation, live link health, production smoke checks, and accessibility smoke coverage. The accessibility gate exposed an existing primary-button contrast issue, so this also darkens the button-specific accent variables to meet WCAG AA contrast while preserving the existing palette.

## Changes

- Added repository hygiene and workflow hygiene scripts, plus security tests for them.
- Added production smoke validation for deployed page markers and security headers.
- Added axe-powered Playwright accessibility smoke tests for index, reading, and offline pages.
- Added advisory GitHub workflows for dependency review, live link health, production smoke, and full release-candidate validation.
- Extended the existing Scan workflow with hygiene, workflow, and link preflight gates.
- Added `@axe-core/playwright` and `yaml` dev dependencies.

## Why

The portfolio already had build, scan, CodeQL, vendor, and integration coverage. These additions close CI gaps around accidental local files, workflow drift, deterministic link safety, dependency manifest review, deployed-site health, and accessibility regressions.

## Testing

- `npm run check:hygiene` — passed
- `npm run check:workflows` — passed
- `npm run check:links:preflight` — passed, checked 114 external URL references
- `npm run test:security` — passed, 71 tests
- `PLAYWRIGHT_PORT=4175 npm run check:accessibility` — passed, 6 tests
- `PLAYWRIGHT_PORT=4176 npm run validate:full` — passed end-to-end
- `npm run check:production -- --attempts 1 --timeout-ms 10000` — passed against the live site
- `git diff --check` — passed

Note: the first local `npm run validate:full` attempt hit an existing local Playwright port conflict on `4173`; rerunning on `4176` passed.

## Risk

Risk is moderate-low. The required Scan context becomes stricter, but the new standalone workflows are advisory unless branch protection is changed later. The CSS change is narrowly scoped to primary button colors and was validated by axe.

## Rollback Plan

Revert this PR. No data migration or external resource change is required.

## Notes for Reviewers

- Review `scripts/check-workflow-hygiene.mjs` carefully because it codifies CI policy.
- Keep the new advisory workflows non-required until they have a few stable runs.

## Linked Issues

None.