### PR TITLE
[codex] build(deps): bump CodeQL action to 4.36.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,10 +29,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # ratchet:github/codeql-action@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # ratchet:github/codeql-action@v4
         with:
           languages: javascript
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # ratchet:github/codeql-action@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # ratchet:github/codeql-action@v4
         with:
           category: "/language:javascript"


### PR DESCRIPTION
## Summary
- updates both `github/codeql-action/init` and `github/codeql-action/analyze` to Dependabot's proposed 4.36.2 SHA
- keeps the two CodeQL action steps on the same commit to avoid the split-update mismatch seen in #135 and #136

## Validation
- `git diff --check`
- `npm ci --ignore-scripts`
- `npm run check:workflows`

Supersedes #135 and #136 if this combined PR passes CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CodeQL workflow to use newer pinned versions of the analysis actions.
  * No changes to app functionality or public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->