### PR TITLE
fix(security): verify service worker message origins

### DIFF
--- a/pwabuilder-sw.js
+++ b/pwabuilder-sw.js
@@ -24,6 +24,10 @@ function isTrustedWindowClient(source) {
   }
 }
 
+function isTrustedMessageOrigin(event) {
+  return event && typeof event.origin === 'string' && event.origin === self.location.origin;
+}
+
 function isSkipWaitingMessage(data) {
   if (!data || typeof data !== 'object') {
     return false;
@@ -42,6 +46,10 @@ function isSkipWaitingMessage(data) {
 
 self.addEventListener('message', (event) => {
   if (!isSkipWaitingMessage(event.data)) {
+    return;
+  }
+
+  if (!isTrustedMessageOrigin(event)) {
     return;
   }
 

--- a/tests/security/service-worker-message.test.mjs
+++ b/tests/security/service-worker-message.test.mjs
@@ -8,9 +8,12 @@ test('service worker validates source and schema before skipWaiting', () => {
   assert.match(content, /function\s+isTrustedWindowClient/);
   assert.match(content, /source\.type\s*!==\s*'window'/);
   assert.match(content, /new URL\(source\.url\)\.origin\s*===\s*self\.location\.origin/);
+  assert.match(content, /function\s+isTrustedMessageOrigin/);
+  assert.match(content, /event\.origin\s*===\s*self\.location\.origin/);
   assert.match(content, /function\s+isSkipWaitingMessage/);
   assert.match(content, /SW_UPDATE_TOKEN_PATTERN/);
   assert.match(content, /!isSkipWaitingMessage\(event\.data\)/);
+  assert.match(content, /!isTrustedMessageOrigin\(event\)/);
   assert.match(content, /!isTrustedWindowClient\(event\.source\)/);
   assert.doesNotMatch(content, /event\.data\s*&&\s*event\.data\.type\s*===\s*'SKIP_WAITING'/);
 });


### PR DESCRIPTION
## Summary
- Require service worker update messages to carry a same-origin `event.origin` before `skipWaiting()` can run
- Keep the existing same-origin window client URL validation as a second guard
- Extend the service worker security regression test to require the explicit origin check

## Validation
- `npm run test:security`
- `npm run validate:full`

## Risk
- Low: scoped to service-worker update activation messages. Same-origin update prompts continue to send the same structured payload, now with explicit browser origin verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for app update messages before accepting a “skip waiting” request.
  * Messages are now checked against the app’s own origin first, helping prevent unauthorized update triggers.
  * Existing checks for message content and trusted sender windows still apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->