### PR TITLE
feat: publish OAuth and OIDC discovery metadata

### DIFF
--- a/.well-known/oauth-authorization-server
+++ b/.well-known/oauth-authorization-server
@@ -1,0 +1,18 @@
+{
+  "issuer": "https://leonardwongly.cloudflareaccess.com",
+  "authorization_endpoint": "https://leonardwongly.cloudflareaccess.com/authorize",
+  "token_endpoint": "https://leonardwongly.cloudflareaccess.com/token",
+  "jwks_uri": "https://leonardwongly.cloudflareaccess.com/cdn-cgi/access/certs",
+  "scopes_supported": [
+    "openid"
+  ],
+  "response_types_supported": [
+    "code"
+  ],
+  "grant_types_supported": [
+    "authorization_code"
+  ],
+  "token_endpoint_auth_methods_supported": [
+    "client_secret_basic"
+  ]
+}

--- a/.well-known/openid-configuration
+++ b/.well-known/openid-configuration
@@ -1,0 +1,25 @@
+{
+  "issuer": "https://leonardwongly.cloudflareaccess.com",
+  "authorization_endpoint": "https://leonardwongly.cloudflareaccess.com/authorize",
+  "token_endpoint": "https://leonardwongly.cloudflareaccess.com/token",
+  "jwks_uri": "https://leonardwongly.cloudflareaccess.com/cdn-cgi/access/certs",
+  "grant_types_supported": [
+    "authorization_code"
+  ],
+  "response_types_supported": [
+    "code"
+  ],
+  "scopes_supported": [
+    "openid"
+  ],
+  "subject_types_supported": [
+    "public"
+  ],
+  "id_token_signing_alg_values_supported": [
+    "RS256"
+  ],
+  "token_endpoint_auth_methods_supported": [
+    "client_secret_basic",
+    "client_secret_post"
+  ]
+}

--- a/_headers
+++ b/_headers
@@ -24,6 +24,16 @@
 /.well-known/describedby
   Content-Type: application/json
 
+/.well-known/openid-configuration
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600
+
+/.well-known/oauth-authorization-server
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600
+
 /*.html
   Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-RBh5ZtcP26aZFp/EGYy/BT1gSD595lvp8sWO2T9xesI='; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
   Access-Control-Allow-Origin: https://leonardwong.tech

--- a/src/_headers.template
+++ b/src/_headers.template
@@ -24,6 +24,16 @@
 /.well-known/describedby
   Content-Type: application/json
 
+/.well-known/openid-configuration
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600
+
+/.well-known/oauth-authorization-server
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600
+
 /*.html
   Content-Security-Policy: default-src 'self'; script-src 'self'{{CSP_SCRIPT_HASHES}}; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
   Access-Control-Allow-Origin: https://leonardwong.tech

--- a/tests/security/oauth-discovery.test.mjs
+++ b/tests/security/oauth-discovery.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const projectRoot = path.resolve(import.meta.dirname, '../..');
+const expectedIssuer = 'https://leonardwongly.cloudflareaccess.com';
+const metadataPaths = [
+  '.well-known/openid-configuration',
+  '.well-known/oauth-authorization-server'
+];
+
+test('OAuth/OIDC discovery metadata exposes the required endpoint fields', () => {
+  for (const relativePath of metadataPaths) {
+    const absolutePath = path.join(projectRoot, relativePath);
+    assert.ok(fs.existsSync(absolutePath), `missing discovery document: ${relativePath}`);
+
+    const metadata = JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+    for (const field of [
+      'issuer',
+      'authorization_endpoint',
+      'token_endpoint',
+      'jwks_uri'
+    ]) {
+      assert.equal(typeof metadata[field], 'string', `${relativePath}: ${field} must be a URL string`);
+      assert.match(metadata[field], /^https:\/\//, `${relativePath}: ${field} must use HTTPS`);
+    }
+
+    assert.equal(metadata.issuer, expectedIssuer);
+    assert.ok(Array.isArray(metadata.grant_types_supported));
+    assert.ok(metadata.grant_types_supported.includes('authorization_code'));
+    assert.ok(Array.isArray(metadata.response_types_supported));
+    assert.ok(metadata.response_types_supported.includes('code'));
+  }
+});
+
+test('discovery routes are delivered as public JSON', () => {
+  const headers = fs.readFileSync(path.join(projectRoot, '_headers'), 'utf8');
+
+  for (const route of metadataPaths.map((value) => `/${value}`)) {
+    const block = headers.match(new RegExp(`${route.replaceAll('/', '\\/')}\\n([\\s\\S]*?)(?=\\n\\n|$)`))?.[1] ?? '';
+    assert.match(block, /Content-Type: application\/json; charset=utf-8/);
+    assert.match(block, /Access-Control-Allow-Origin: \*/);
+  }
+});


### PR DESCRIPTION
## Summary

Publishes OAuth 2.0 and OpenID Connect discovery metadata for the portfolio's Cloudflare Access authorization server.

## Changes

- Added `/.well-known/openid-configuration`.
- Added `/.well-known/oauth-authorization-server`.
- Included issuer, authorization endpoint, token endpoint, JWKS URI, grant types, and response types.
- Added explicit JSON content type, CORS, and cache headers for both routes.
- Added regression tests for metadata fields and response header policy.

## Why

Agents need a standards-defined way to discover the authorization server before authenticating with protected APIs.

## Testing

- `npm run build` — passed locally.
- `npm run test:security` — 133 tests passed locally.
- Targeted OAuth/OIDC discovery tests — 4 passed locally.
- `git diff --check` — passed.
- Live `isitagentready.com` scan was unavailable because this environment could not resolve the public scanner host.

## Risk

Low repository risk. The documents point to the configured Cloudflare Access issuer; the Access application must expose the listed authorization and token routes and its JWKS endpoint for an interactive flow to work.

## Rollback Plan

Revert this pull request or remove the two well-known documents and their header blocks.

## Notes for Reviewers

Please verify that the Cloudflare Access team configuration uses the same issuer and endpoint paths published in the metadata.
