### PR TITLE
feat: add MPP payment discovery metadata

### DIFF
--- a/_headers
+++ b/_headers
@@ -9,6 +9,11 @@
   Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-RBh5ZtcP26aZFp/EGYy/BT1gSD595lvp8sWO2T9xesI='; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
   Access-Control-Allow-Origin: https://leonardwong.tech
 
+/openapi.json
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=300
+
 /*.html
   Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-RBh5ZtcP26aZFp/EGYy/BT1gSD595lvp8sWO2T9xesI='; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
   Access-Control-Allow-Origin: https://leonardwong.tech

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,67 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Leonard Wong Portfolio Services",
+    "version": "1.0.0",
+    "description": "Machine-readable discovery for paid portfolio and agent-readiness services."
+  },
+  "servers": [
+    {
+      "url": "https://leonardwong.tech"
+    }
+  ],
+  "x-service-info": {
+    "name": "Leonard Wong Portfolio Services",
+    "description": "Secure software-engineering and agent-readiness consulting services.",
+    "categories": [
+      "software-engineering",
+      "security",
+      "agent-readiness"
+    ]
+  },
+  "paths": {
+    "/api/portfolio-review": {
+      "post": {
+        "operationId": "requestPortfolioReview",
+        "summary": "Request a paid portfolio architecture review",
+        "description": "Submit a project brief for a written architecture and security review.",
+        "x-payment-info": {
+          "intent": "charge",
+          "method": "stripe",
+          "amount": 250,
+          "currency": "USD",
+          "description": "Portfolio architecture and security review"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "project"
+                ],
+                "properties": {
+                  "project": {
+                    "type": "string",
+                    "description": "A short description of the project to review."
+                  },
+                  "focus": {
+                    "type": "string",
+                    "description": "Optional review focus, such as security or platform architecture."
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Review request accepted for fulfillment."
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pretest:integration": "npx --no-install playwright install chromium",
     "test:integration": "npx --no-install playwright test tests/integration/mobile-nav-and-accordion.spec.mjs --config=playwright.config.mjs",
     "audit:high": "npm audit --audit-level=high",
-    "check:generated": "git diff --exit-code -- index.html work.html case-study-agentforge.html case-study-agentic.html case-study-apple-calendar-mcp.html reading.html offline.html _headers",
+    "check:generated": "git diff --exit-code -- index.html work.html case-study-agentforge.html case-study-agentic.html case-study-apple-calendar-mcp.html reading.html offline.html _headers openapi.json",
     "check:hygiene": "node scripts/check-repository-hygiene.mjs",
     "check:assets": "node scripts/check-performance-budget.mjs",
     "precheck:accessibility": "npx --no-install playwright install chromium",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -16,6 +16,7 @@ const srcDir = path.join(projectRoot, 'src');
 const partialDir = path.join(projectRoot, 'partials');
 const dataDir = path.join(projectRoot, 'data');
 const headersTemplatePath = path.join(srcDir, '_headers.template');
+const discoveryFiles = ['openapi.json'];
 
 const partials = {
   NAV: fs.readFileSync(path.join(partialDir, 'nav.html'), 'utf8'),
@@ -1789,6 +1790,16 @@ function buildSite() {
   const headersTemplate = fs.readFileSync(headersTemplatePath, 'utf8');
   const headersContent = injectCspScriptHashes(headersTemplate, indexPage);
   fs.writeFileSync(path.join(projectRoot, '_headers'), headersContent);
+
+  discoveryFiles.forEach((file) => {
+    const sourcePath = path.join(srcDir, file);
+    if (!fs.existsSync(sourcePath)) {
+      throw new Error(`Missing discovery source file: ${sourcePath}`);
+    }
+    const targetPath = path.join(projectRoot, file);
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.writeFileSync(targetPath, fs.readFileSync(sourcePath, 'utf8'));
+  });
 
   console.log('Build complete: generated', pages.join(', '));
 }

--- a/src/_headers.template
+++ b/src/_headers.template
@@ -9,6 +9,11 @@
   Content-Security-Policy: default-src 'self'; script-src 'self'{{CSP_SCRIPT_HASHES}}; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
   Access-Control-Allow-Origin: https://leonardwong.tech
 
+/openapi.json
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=300
+
 /*.html
   Content-Security-Policy: default-src 'self'; script-src 'self'{{CSP_SCRIPT_HASHES}}; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
   Access-Control-Allow-Origin: https://leonardwong.tech

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -1,0 +1,67 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Leonard Wong Portfolio Services",
+    "version": "1.0.0",
+    "description": "Machine-readable discovery for paid portfolio and agent-readiness services."
+  },
+  "servers": [
+    {
+      "url": "https://leonardwong.tech"
+    }
+  ],
+  "x-service-info": {
+    "name": "Leonard Wong Portfolio Services",
+    "description": "Secure software-engineering and agent-readiness consulting services.",
+    "categories": [
+      "software-engineering",
+      "security",
+      "agent-readiness"
+    ]
+  },
+  "paths": {
+    "/api/portfolio-review": {
+      "post": {
+        "operationId": "requestPortfolioReview",
+        "summary": "Request a paid portfolio architecture review",
+        "description": "Submit a project brief for a written architecture and security review.",
+        "x-payment-info": {
+          "intent": "charge",
+          "method": "stripe",
+          "amount": 250,
+          "currency": "USD",
+          "description": "Portfolio architecture and security review"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "project"
+                ],
+                "properties": {
+                  "project": {
+                    "type": "string",
+                    "description": "A short description of the project to review."
+                  },
+                  "focus": {
+                    "type": "string",
+                    "description": "Optional review focus, such as security or platform architecture."
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Review request accepted for fulfillment."
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/security/mpp-payment-discovery.test.mjs
+++ b/tests/security/mpp-payment-discovery.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const projectRoot = path.resolve(new URL('../..', import.meta.url).pathname);
+
+function readOpenApi(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(projectRoot, relativePath), 'utf8'));
+}
+
+function payableOperations(document) {
+  return Object.entries(document.paths ?? {}).flatMap(([pathName, pathItem]) =>
+    Object.entries(pathItem ?? {})
+      .filter(([method, operation]) => ['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'].includes(method) && operation?.['x-payment-info'])
+      .map(([method, operation]) => ({ pathName, method, payment: operation['x-payment-info'] }))
+  );
+}
+
+test('MPP OpenAPI discovery is published and generated from the source document', () => {
+  const source = readOpenApi('src/openapi.json');
+  const generated = readOpenApi('openapi.json');
+
+  assert.deepEqual(generated, source);
+  assert.equal(generated.openapi, '3.1.0');
+  assert.ok(generated.info?.title);
+
+  const operations = payableOperations(generated);
+  assert.ok(operations.length > 0, 'expected at least one payable operation');
+
+  const intents = new Set(['charge', 'session']);
+  const methods = new Set(['tempo', 'stripe', 'lightning', 'card']);
+  operations.forEach(({ pathName, method, payment }) => {
+    assert.ok(intents.has(payment.intent), `${method.toUpperCase()} ${pathName} has an unsupported payment intent`);
+    assert.ok(methods.has(payment.method), `${method.toUpperCase()} ${pathName} has an unsupported payment method`);
+    assert.equal(typeof payment.amount, 'number', `${method.toUpperCase()} ${pathName} must declare a numeric amount`);
+    assert.ok(Number.isFinite(payment.amount) && payment.amount > 0, `${method.toUpperCase()} ${pathName} must declare a positive amount`);
+  });
+
+  assert.ok(Array.isArray(generated['x-service-info']?.categories));
+  assert.ok(generated['x-service-info'].categories.length > 0);
+});


### PR DESCRIPTION
## Summary

Publishes an OpenAPI 3.1 document at `/openapi.json` with Machine Payment Protocol (MPP) payment discovery metadata.

## Changes

- Added a source-backed OpenAPI document with a payable portfolio-review operation and `x-payment-info` (`charge`, `stripe`, USD 250).
- Added top-level `x-service-info` categories for software engineering, security, and agent readiness.
- Updated the static build and headers so the document is published at the site root with JSON content type, CORS, and short public caching.
- Added regression coverage for source/generated parity and required MPP metadata fields.

## Why

AI agents need a machine-readable way to discover payable endpoints and the payment details required to invoke them.

## Testing

- `node scripts/build.js` — passed
- `node --test tests/security/mpp-payment-discovery.test.mjs` — passed
- `npm run test:security` — passed (106 tests)
- `npm run check:generated` — passed
- `git diff --check` — passed

## Risk

Low. This adds static discovery metadata and publication wiring; it does not add payment processing or data migrations.

## Rollback Plan

Revert commit `841bf67`.

## Notes for Reviewers

Please verify that the documented `/api/portfolio-review` contract matches the intended production payment handler before enabling it for live traffic.
