### PR TITLE
feat: add x402 payment middleware

### DIFF
--- a/docs/x402.md
+++ b/docs/x402.md
@@ -1,0 +1,40 @@
+# x402 payments
+
+`POST /api/scan` is protected by the x402 v2 HTTP payment protocol. Requests
+without a valid `Payment-Signature` (or legacy `X-Payment`) header receive
+HTTP `402` with payment requirements that an x402-compatible agent can use to
+create and settle a payment automatically.
+
+The Cloudflare Pages Function uses `@x402/hono` and the exact EVM scheme. The
+default network is Base Sepolia (`eip155:84532`) and the default facilitator is
+`https://x402.org/facilitator`.
+
+## Deployment configuration
+
+Set these Pages/Workers environment variables before deploying the function:
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `X402_PAY_TO` | yes | — | Recipient EVM wallet address (`0x` plus 40 hex characters) |
+| `X402_FACILITATOR_URL` | no | `https://x402.org/facilitator` | HTTPS x402 facilitator endpoint |
+| `X402_NETWORK` | no | `eip155:84532` | CAIP-2 EVM network identifier |
+| `X402_PRICE` | no | `$0.01` | Per-request price in USD notation |
+
+The function fails closed with `503` when the recipient wallet is missing or
+invalid. No private key is needed by the application: the facilitator verifies
+and settles the payer's signed payment.
+
+## Smoke test
+
+With the site deployed and `X402_PAY_TO` configured, an unpaid request should
+return `402` and include a JSON payment requirement:
+
+```bash
+curl -i -X POST https://YOUR-SITE.com/api/scan \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  --data '{"url":"https://example.com"}'
+```
+
+After an x402 client pays and retries with `Payment-Signature`, the route
+returns the scan request metadata as JSON.

--- a/functions/api/scan.js
+++ b/functions/api/scan.js
@@ -1,0 +1,282 @@
+import { Hono } from 'hono';
+import { paymentMiddleware } from '@x402/hono';
+import { HTTPFacilitatorClient, x402ResourceServer } from '@x402/core/server';
+import { registerExactEvmScheme } from '@x402/evm/exact/server';
+
+const DEFAULT_FACILITATOR_URL = 'https://x402.org/facilitator';
+const DEFAULT_NETWORK = 'eip155:84532';
+const DEFAULT_PRICE = '$0.01';
+const MAX_BODY_BYTES = 16 * 1024;
+const MAX_NETWORK_LENGTH = 64;
+const MAX_PRICE_LENGTH = 32;
+const MAX_FACILITATOR_URL_LENGTH = 2048;
+const WALLET_PATTERN = /^0x[a-fA-F0-9]{40}$/u;
+const NETWORK_PATTERN = /^eip155:\d+$/u;
+const FACILITATOR_HOST_ALLOWLIST = new Set(['x402.org']);
+
+class RequestBodyTooLargeError extends Error {
+  constructor() {
+    super('Request body is too large');
+    this.name = 'RequestBodyTooLargeError';
+  }
+}
+
+function runtimeEnv(env = {}) {
+  const processEnv = typeof process !== 'undefined' && process.env ? process.env : {};
+  return {
+    ...processEnv,
+    ...env
+  };
+}
+
+function httpsUrl(value, fieldName) {
+  if (value.length > MAX_FACILITATOR_URL_LENGTH) {
+    throw new Error(`${fieldName} must not exceed ${MAX_FACILITATOR_URL_LENGTH} characters`);
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${fieldName} must be an absolute HTTPS URL`);
+  }
+
+  const hostname = parsed.hostname.toLowerCase().replace(/\.+$/u, '');
+  if (
+    parsed.protocol !== 'https:' ||
+    parsed.username ||
+    parsed.password ||
+    parsed.hash ||
+    parsed.port ||
+    !FACILITATOR_HOST_ALLOWLIST.has(hostname)
+  ) {
+    throw new Error(`${fieldName} must be an absolute HTTPS URL`);
+  }
+
+  return parsed.toString().replace(/\/$/u, '');
+}
+
+export function getX402Config(env = {}) {
+  const values = runtimeEnv(env);
+  const payTo = typeof values.X402_PAY_TO === 'string' ? values.X402_PAY_TO.trim() : '';
+  if (!WALLET_PATTERN.test(payTo)) {
+    throw new Error('X402_PAY_TO must be a valid EVM wallet address');
+  }
+
+  const network = typeof values.X402_NETWORK === 'string' && values.X402_NETWORK.trim()
+    ? values.X402_NETWORK.trim()
+    : DEFAULT_NETWORK;
+  if (!NETWORK_PATTERN.test(network)) {
+    throw new Error('X402_NETWORK must be a CAIP-2 EVM network such as eip155:84532');
+  }
+  if (network.length > MAX_NETWORK_LENGTH) {
+    throw new Error(`X402_NETWORK must not exceed ${MAX_NETWORK_LENGTH} characters`);
+  }
+
+  const price = typeof values.X402_PRICE === 'string' && values.X402_PRICE.trim()
+    ? values.X402_PRICE.trim()
+    : DEFAULT_PRICE;
+  if (!/^\$\d+(?:\.\d{1,6})?$/u.test(price)) {
+    throw new Error('X402_PRICE must be a dollar amount such as $0.01');
+  }
+  if (price.length > MAX_PRICE_LENGTH) {
+    throw new Error(`X402_PRICE must not exceed ${MAX_PRICE_LENGTH} characters`);
+  }
+
+  return {
+    facilitatorUrl: httpsUrl(
+      typeof values.X402_FACILITATOR_URL === 'string' && values.X402_FACILITATOR_URL.trim()
+        ? values.X402_FACILITATOR_URL.trim()
+        : DEFAULT_FACILITATOR_URL,
+      'X402_FACILITATOR_URL'
+    ),
+    network,
+    payTo,
+    price
+  };
+}
+
+function jsonError(message, status) {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'no-store',
+      'Content-Type': 'application/json; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff'
+    }
+  });
+}
+
+function createResourceServer(config, facilitatorClient) {
+  const client = facilitatorClient ?? new HTTPFacilitatorClient({ url: config.facilitatorUrl });
+  const server = new x402ResourceServer(client);
+  return registerExactEvmScheme(server, { networks: [config.network] });
+}
+
+/**
+ * Parse a JSON request body while retaining at most MAX_BODY_BYTES in memory.
+ * Content-Length is only an optimization: streamed/chunked requests are
+ * counted as bytes arrive and are rejected as soon as the limit is crossed.
+ */
+export async function readBoundedJson(request) {
+  const header = typeof request.header === 'function'
+    ? request.header.bind(request)
+    : (name) => request.headers?.get(name);
+  const declaredLength = header('content-length');
+  if (/^\s*\d+\s*$/u.test(declaredLength ?? '') && Number(declaredLength) > MAX_BODY_BYTES) {
+    throw new RequestBodyTooLargeError();
+  }
+
+  const body = (request.raw ?? request)?.body;
+  if (!body || typeof body.getReader !== 'function') {
+    throw new Error('Request body must be valid JSON');
+  }
+
+  const reader = body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
+      total += chunk.byteLength;
+      if (total > MAX_BODY_BYTES) {
+        throw new RequestBodyTooLargeError();
+      }
+      chunks.push(chunk);
+    }
+  } catch (error) {
+    try {
+      await reader.cancel();
+    } catch {
+      // The original parsing/size error is the actionable response.
+    }
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  let text;
+  try {
+    text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error('Request body must be valid JSON');
+  }
+  return JSON.parse(text);
+}
+
+export function createScanApp(env = {}, { facilitatorClient, server } = {}) {
+  const config = getX402Config(env);
+  const resourceServer = server ?? createResourceServer(config, facilitatorClient);
+  const app = new Hono();
+
+  app.use('*', async (c, next) => {
+    c.header('Access-Control-Allow-Origin', '*');
+    c.header('Access-Control-Expose-Headers', 'PAYMENT-REQUIRED, PAYMENT-RESPONSE');
+    await next();
+  });
+
+  app.use(
+    '*',
+    paymentMiddleware(
+      {
+        'POST /api/scan': {
+          accepts: {
+            scheme: 'exact',
+            price: config.price,
+            network: config.network,
+            payTo: config.payTo,
+            maxTimeoutSeconds: 300
+          },
+          description: 'Run an AgentReady scan for a public HTTPS site',
+          mimeType: 'application/json'
+        }
+      },
+      resourceServer
+    )
+  );
+
+  app.options('/api/scan', (c) => new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Headers': 'Content-Type, Payment-Signature, X-Payment',
+      'Access-Control-Allow-Methods': 'OPTIONS, POST',
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'no-store'
+    }
+  }));
+
+  app.post('/api/scan', async (c) => {
+    let payload;
+    try {
+      payload = await readBoundedJson(c.req);
+    } catch (error) {
+      if (error instanceof RequestBodyTooLargeError) {
+        return jsonError('Request body is too large', 413);
+      }
+      return jsonError('Request body must be valid JSON', 400);
+    }
+
+    const url = typeof payload?.url === 'string' ? payload.url.trim() : '';
+    let parsedUrl;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      return jsonError('url must be an absolute HTTPS URL', 400);
+    }
+
+    if (parsedUrl.protocol !== 'https:' || parsedUrl.username || parsedUrl.password || parsedUrl.hash) {
+      return jsonError('url must be an absolute HTTPS URL', 400);
+    }
+
+    return c.json({
+      ok: true,
+      service: 'agent-ready-scan',
+      url: parsedUrl.toString(),
+      payment: {
+        network: config.network,
+        price: config.price,
+        protocol: 'x402'
+      }
+    });
+  });
+
+  return app;
+}
+
+const apps = new Map();
+
+function appFor(env) {
+  const config = getX402Config(env);
+  const key = `${config.facilitatorUrl}|${config.network}|${config.payTo}|${config.price}`;
+  let app = apps.get(key);
+  if (!app) {
+    app = createScanApp(env);
+    apps.set(key, app);
+  }
+  return app;
+}
+
+export async function onRequest({ request, env, ctx }) {
+  try {
+    return await appFor(env).fetch(request, env, ctx);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'x402 configuration is invalid';
+    if (message.startsWith('X402_')) {
+      return jsonError('x402 payment configuration is unavailable', 503);
+    }
+    throw error;
+  }
+}
+
+export { DEFAULT_FACILITATOR_URL, DEFAULT_NETWORK, DEFAULT_PRICE };

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,12 @@
     "": {
       "name": "projectportfolio",
       "version": "0.0.0",
+      "dependencies": {
+        "@x402/core": "2.21.0",
+        "@x402/evm": "2.21.0",
+        "@x402/hono": "2.21.0",
+        "hono": "4.13.1"
+      },
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "1.62.1",
@@ -15,6 +21,12 @@
       "engines": {
         "node": ">=24"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@axe-core/playwright": {
       "version": "4.12.1",
@@ -27,6 +39,45 @@
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@playwright/test": {
@@ -45,6 +96,172 @@
         "node": ">=20"
       }
     },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@signinwithethereum/siwe": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@signinwithethereum/siwe/-/siwe-4.2.0.tgz",
+      "integrity": "sha512-6W+oyKgMFUZRJI4o9P9mTMzrokkXfu3tq1/CfOJj9QrMqyPqujJqv1xnxUAqDQwWVyCA8TMg0Fxk/+gXrDg2Nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@signinwithethereum/siwe-parser": "^4.2.0"
+      },
+      "peerDependencies": {
+        "ethers": "^5.7.0 || ^6.13.0",
+        "viem": "^2.7.0"
+      },
+      "peerDependenciesMeta": {
+        "ethers": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@signinwithethereum/siwe-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@signinwithethereum/siwe-parser/-/siwe-parser-4.2.0.tgz",
+      "integrity": "sha512-e3edh8XpZrEjbzVYc0BZ4ySFOa8RKTZOQTafSf1E6ejCB5XcBH93jEpYmjzry1EEocgMNq4KlB3YunsFNCXakQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.7.0",
+        "apg-js": "^4.4.0"
+      }
+    },
+    "node_modules/@x402/core": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.21.0.tgz",
+      "integrity": "sha512-0djKE7V5/JKDMrjRe5he3DoMFzlbVnUcvMmLAb2j6OoAJDamupkFh6fFrXeoHwjkBIxOFUzjGI4FVixz2dMxSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/evm": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@x402/evm/-/evm-2.21.0.tgz",
+      "integrity": "sha512-VZtPz26IxhfAQbHHmyG7nCY/0jLH9QIgNqRztT1ae93dc9uSGUyn5bofzA3Wxq7lND3WDFir0QAQ2LBqoFeMrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@x402/core": "~2.21.0",
+        "viem": "^2.48.11",
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/extensions": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@x402/extensions/-/extensions-2.21.0.tgz",
+      "integrity": "sha512-0cZTRVtnWUUsp9KxBvbMERtLKo+57Ru1IhbAHtpgNdK08/LJWtK6CpqM4wgta8nMPth3jMvB/PdS3OdNaEPaBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.0",
+        "@scure/base": "^1.2.6",
+        "@signinwithethereum/siwe": "^4.1.0",
+        "@x402/core": "~2.21.0",
+        "ajv": "^8.17.1",
+        "jose": "^5.9.6",
+        "tweetnacl": "^1.0.3",
+        "viem": "^2.48.11",
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/hono": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@x402/hono/-/hono-2.21.0.tgz",
+      "integrity": "sha512-5OjD+jh0p0W4TvTmcwxYkRKfwgzldLE9PomOnVls6Gq6fsYYdajHuDxd8ZQXb8m9S/3JwOYK3Ay8v2hLv/Mv4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@x402/core": "~2.21.0",
+        "@x402/extensions": "~2.21.0"
+      },
+      "peerDependencies": {
+        "@x402/paywall": "^2.21.0",
+        "hono": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@x402/paywall": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/apg-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.4.0.tgz",
+      "integrity": "sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/axe-core": {
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
@@ -54,6 +271,34 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -68,6 +313,90 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/ox": {
+      "version": "0.14.33",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.33.tgz",
+      "integrity": "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/playwright": {
@@ -102,6 +431,87 @@
         "node": ">=20"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/viem": {
+      "version": "2.55.11",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.11.tgz",
+      "integrity": "sha512-RR5MwtdUnFfqw6ZGoFptizywyLOkLuhTL7UafoP3Irf2upXpANakQkLgGqY4H7A7+8JBxjUs6lElGF5zuGjMEw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.33",
+        "ws": "8.21.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -116,6 +526,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -38,5 +38,11 @@
     "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "1.62.1",
     "yaml": "^2.9.0"
+  },
+  "dependencies": {
+    "@x402/core": "2.21.0",
+    "@x402/evm": "2.21.0",
+    "@x402/hono": "2.21.0",
+    "hono": "4.13.1"
   }
 }

--- a/tests/security/x402.test.mjs
+++ b/tests/security/x402.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const functionSource = fs.readFileSync('functions/api/scan.js', 'utf8');
+const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+
+test('x402 scan function uses the supported Hono middleware and server scheme', () => {
+  assert.equal(packageJson.dependencies['@x402/hono'], '2.21.0');
+  assert.equal(packageJson.dependencies['@x402/core'], '2.21.0');
+  assert.equal(packageJson.dependencies['@x402/evm'], '2.21.0');
+  assert.match(functionSource, /paymentMiddleware/);
+  assert.match(functionSource, /HTTPFacilitatorClient/);
+  assert.match(functionSource, /registerExactEvmScheme/);
+});
+
+test('x402 scan route requires a validated wallet and protects POST /api/scan', () => {
+  assert.match(functionSource, /X402_PAY_TO/);
+  assert.match(functionSource, /WALLET_PATTERN/);
+  assert.match(functionSource, /'POST \/api\/scan'/);
+  assert.match(functionSource, /app\.post\('\/api\/scan'/);
+  assert.match(functionSource, /price: config\.price/);
+  assert.match(functionSource, /network: config\.network/);
+  assert.match(functionSource, /payTo: config\.payTo/);
+});
+
+test('x402 configuration defaults to the public facilitator and Base Sepolia', () => {
+  assert.match(functionSource, /https:\/\/x402\.org\/facilitator/);
+  assert.match(functionSource, /eip155:84532/);
+  assert.match(functionSource, /503/);
+});
+
+test('unpaid scan requests receive x402 payment requirements', async () => {
+  const { createScanApp } = await import('../../functions/api/scan.js');
+  const facilitator = {
+    async getSupported() {
+      return {
+        kinds: [{ x402Version: 2, scheme: 'exact', network: 'eip155:84532' }]
+      };
+    }
+  };
+  const app = createScanApp(
+    { X402_PAY_TO: '0x1111111111111111111111111111111111111111' },
+    { facilitatorClient: facilitator }
+  );
+  const response = await app.request('https://example.test/api/scan', {
+    method: 'POST',
+    headers: { accept: 'application/json', 'content-type': 'application/json' },
+    body: JSON.stringify({ url: 'https://example.com' })
+  });
+
+  assert.equal(response.status, 402);
+  const encodedRequirements = response.headers.get('payment-required');
+  assert.ok(encodedRequirements, 'expected the v2 PAYMENT-REQUIRED header');
+  const requirements = JSON.parse(Buffer.from(encodedRequirements, 'base64').toString('utf8'));
+  assert.equal(requirements.x402Version, 2);
+  assert.equal(requirements.accepts[0].network, 'eip155:84532');
+  assert.equal(requirements.accepts[0].payTo, '0x1111111111111111111111111111111111111111');
+});
+
+test('missing wallet configuration fails closed before exposing the route', async () => {
+  const { onRequest } = await import('../../functions/api/scan.js');
+  const response = await onRequest({
+    request: new Request('https://example.test/api/scan', { method: 'POST' }),
+    env: { X402_PAY_TO: '' }
+  });
+
+  assert.equal(response.status, 503);
+});
+
+test('bounded JSON parsing rejects an oversized streamed body without Content-Length', async () => {
+  const { readBoundedJson } = await import('../../functions/api/scan.js');
+  const body = JSON.stringify({ url: 'https://example.com', padding: 'x'.repeat(16 * 1024) });
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+      controller.close();
+    }
+  });
+  const request = new Request('https://example.test/api/scan', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: stream,
+    duplex: 'half'
+  });
+
+  assert.equal(request.headers.get('content-length'), null);
+  await assert.rejects(
+    () => readBoundedJson({ header: (name) => request.headers.get(name), raw: request }),
+    { name: 'RequestBodyTooLargeError', message: 'Request body is too large' }
+  );
+});
+
+test('bounded JSON parsing counts multiple chunks toward the byte limit', async () => {
+  const { readBoundedJson } = await import('../../functions/api/scan.js');
+  const chunks = [
+    new TextEncoder().encode('{"url":"https://example.com","padding":"'),
+    new TextEncoder().encode('x'.repeat(16 * 1024)),
+    new TextEncoder().encode('"}')
+  ];
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    }
+  });
+  const request = new Request('https://example.test/api/scan', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: stream,
+    duplex: 'half'
+  });
+
+  await assert.rejects(
+    () => readBoundedJson(request),
+    { name: 'RequestBodyTooLargeError' }
+  );
+});
+
+test('facilitator and scalar config values are bounded and host-allowlisted', async () => {
+  const { getX402Config } = await import('../../functions/api/scan.js');
+  const wallet = '0x1111111111111111111111111111111111111111';
+
+  assert.throws(
+    () => getX402Config({
+      X402_PAY_TO: wallet,
+      X402_FACILITATOR_URL: 'https://127.0.0.1/facilitator'
+    }),
+    /X402_FACILITATOR_URL must be an absolute HTTPS URL/
+  );
+  assert.throws(
+    () => getX402Config({ X402_PAY_TO: wallet, X402_NETWORK: `eip155:${'9'.repeat(64)}` }),
+    /X402_NETWORK must not exceed/
+  );
+  assert.throws(
+    () => getX402Config({ X402_PAY_TO: wallet, X402_PRICE: `$${'9'.repeat(40)}` }),
+    /X402_PRICE must not exceed/
+  );
+});


### PR DESCRIPTION
## Summary

Adds an x402 v2 payment-protected API route for agent-native HTTP payments.

## Changes

- Added a Cloudflare Pages Function at `POST /api/scan`.
- Added `@x402/hono`, `@x402/core`, and `@x402/evm` integration.
- Configured the public x402 facilitator by default, with environment-controlled wallet, network, price, and facilitator settings.
- Added bounded JSON parsing, HTTPS validation, facilitator host allowlisting, CORS payment-header exposure, and fail-closed configuration handling.
- Added focused x402 documentation and regression coverage.

## Why

Agents need a standard way to discover and fulfill payment requirements over HTTP. The route now returns HTTP 402 with x402 v2 payment requirements when no valid payment signature is supplied.

## Testing

- `npm ci --ignore-scripts` — passed
- `npm run build` — passed
- `npm run test:security` — passed (314 tests)
- `node --test tests/security/x402.test.mjs` — passed (8 tests)
- `node --check functions/api/scan.js` — passed
- `npm audit --audit-level=high` — passed, 0 vulnerabilities
- `git diff --check origin/main...HEAD` — passed

## Screenshots / Recordings

Not applicable.

## Risk

Low to moderate. This adds a new payment-protected serverless route and introduces x402/viem runtime dependencies. The existing static pages are unchanged.

## Rollback Plan

Revert the single commit or remove the `agent/x402-payment-protocol` branch. No database migration is required.

## Notes for Reviewers

- Configure `X402_PAY_TO` in Cloudflare Pages before deployment; the function intentionally returns 503 when the recipient wallet is absent or invalid.
- Defaults target Base Sepolia (`eip155:84532`) and `https://x402.org/facilitator`.
- Please review the facilitator host allowlist and payment route configuration in `functions/api/scan.js`.

## Linked Issues

None.
