### PR TITLE
feat: advertise AP2 support in the A2A Agent Card

### DIFF
--- a/.well-known/agent-card.json
+++ b/.well-known/agent-card.json
@@ -1,0 +1,46 @@
+{
+  "name": "Leonard Wong Portfolio Agent",
+  "description": "An informational agent for Leonard Wong's professional portfolio, experience, projects, and case studies.",
+  "url": "https://leonardwong.tech/",
+  "version": "1.0.0",
+  "protocolVersion": "0.3.0",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "defaultInputModes": [
+    "text"
+  ],
+  "defaultOutputModes": [
+    "text"
+  ],
+  "skills": [
+    {
+      "id": "portfolio-information",
+      "name": "Portfolio information",
+      "description": "Answers questions about Leonard Wong's professional profile, experience, skills, and published work.",
+      "tags": [
+        "portfolio",
+        "profile",
+        "experience"
+      ],
+      "examples": [
+        "What projects has Leonard Wong built?",
+        "Summarize Leonard Wong's AI engineering experience."
+      ]
+    }
+  ],
+  "extensions": [
+    {
+      "uri": "https://github.com/google-agentic-commerce/AP2/tree/v0.1.0",
+      "description": "Optional Agent Payments Protocol support for a shopper agent when an explicitly authorized payment flow is available.",
+      "required": false,
+      "params": {
+        "roles": [
+          "shopper"
+        ]
+      }
+    }
+  ]
+}

--- a/_headers
+++ b/_headers
@@ -35,3 +35,8 @@
 /offline
   Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-RBh5ZtcP26aZFp/EGYy/BT1gSD595lvp8sWO2T9xesI='; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
   Access-Control-Allow-Origin: https://leonardwong.tech
+
+/.well-known/agent-card.json
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600

--- a/src/_headers.template
+++ b/src/_headers.template
@@ -35,3 +35,8 @@
 /offline
   Content-Security-Policy: default-src 'self'; script-src 'self'{{CSP_SCRIPT_HASHES}}; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
   Access-Control-Allow-Origin: https://leonardwong.tech
+
+/.well-known/agent-card.json
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600

--- a/tests/security/agent-card.test.mjs
+++ b/tests/security/agent-card.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const projectRoot = path.resolve(new URL('../..', import.meta.url).pathname);
+const agentCardPath = path.join(projectRoot, '.well-known', 'agent-card.json');
+
+function readAgentCard() {
+  return JSON.parse(fs.readFileSync(agentCardPath, 'utf8'));
+}
+
+test('A2A Agent Card advertises the AP2 shopper extension', () => {
+  const card = readAgentCard();
+  const ap2Extension = card.extensions?.find((extension) => (
+    extension.uri === 'https://github.com/google-agentic-commerce/AP2/tree/v0.1.0'
+  ));
+
+  assert.ok(ap2Extension, 'missing AP2 extension from the Agent Card');
+  assert.deepEqual(ap2Extension.params?.roles, ['shopper']);
+  assert.equal(ap2Extension.required, false);
+});


### PR DESCRIPTION
## Summary

Adds an A2A Agent Card for the portfolio agent and advertises the Agent Payments Protocol (AP2) extension for the shopper role.

## Changes

- Added `/.well-known/agent-card.json` with a standards-shaped A2A Agent Card.
- Added the AP2 extension URI `https://github.com/google-agentic-commerce/AP2/tree/v0.1.0`.
- Declared `params.roles: ["shopper"]` and kept the extension optional because this is an informational, non-commerce agent.
- Added JSON delivery headers and a regression test for the AP2 metadata.

## Why

The site had no A2A Agent Card, so AP2-aware agent discovery could not detect its supported role. This publishes the required extension metadata without falsely advertising the portfolio as a merchant or payment processor.

## Testing

- `npm run build` — passed
- `npm run test:security` — passed, 307 tests
- `node --test tests/security/agent-card.test.mjs` — passed
- `git diff --check` — passed

## Risk

Low. This is static discovery metadata and header configuration; it does not add a checkout, payment processor, or mandate-signing backend.

## Rollback Plan

Revert commit `0370e3f` or close this PR before merge.

## Notes for Reviewers

Please verify that `shopper` is the intended AP2 role for this informational agent. If the site later becomes a merchant or payment service, update the role and `required` flag together with the corresponding transaction implementation.