### PR TITLE
feat: publish Universal Commerce Protocol discovery

### DIFF
--- a/.well-known/ucp
+++ b/.well-known/ucp
@@ -1,0 +1,43 @@
+{
+  "protocol_version": "2026-04-08",
+  "services": {
+    "shopping": {
+      "spec": "https://ucp.dev/2026-04-08/specification/overview",
+      "schema": "https://ucp.dev/2026-04-08/services/shopping/embedded.openrpc.json"
+    }
+  },
+  "capabilities": {
+    "checkout": {
+      "spec": "https://ucp.dev/2026-04-08/specification/checkout",
+      "schema": "https://ucp.dev/2026-04-08/schemas/shopping/checkout.json"
+    }
+  },
+  "endpoints": {
+    "discovery": "https://leonardwong.tech/.well-known/ucp",
+    "content": "https://leonardwong.tech/api/scan"
+  },
+  "ucp": {
+    "version": "2026-04-08",
+    "services": {
+      "dev.ucp.shopping": [
+        {
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/overview",
+          "transport": "embedded",
+          "schema": "https://ucp.dev/2026-04-08/services/shopping/embedded.openrpc.json"
+        }
+      ]
+    },
+    "capabilities": {
+      "dev.ucp.shopping.checkout": [
+        {
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/checkout",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/checkout.json"
+        }
+      ]
+    },
+    "payment_handlers": {}
+  },
+  "signing_keys": []
+}

--- a/_headers
+++ b/_headers
@@ -35,3 +35,8 @@
 /offline
   Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-RBh5ZtcP26aZFp/EGYy/BT1gSD595lvp8sWO2T9xesI='; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
   Access-Control-Allow-Origin: https://leonardwong.tech
+
+/.well-known/ucp
+  Content-Type: application/json; charset=utf-8
+  Cache-Control: public, max-age=300, s-maxage=300
+  Access-Control-Allow-Origin: *

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "test:content": "node --test tests/security/content-parity.test.mjs",
     "test:integration": "npx --no-install playwright install chromium && npx --no-install playwright test tests/integration/mobile-nav-and-accordion.spec.mjs --config=playwright.config.mjs",
     "audit:high": "npm audit --audit-level=high",
-    "check:generated": "git diff --exit-code -- index.html work.html case-study-agentforge.html case-study-agentic.html case-study-apple-calendar-mcp.html reading.html offline.html _headers",
     "check:generated": "git diff --exit-code -- index.html work.html case-study-agentforge.html case-study-agentic.html case-study-apple-calendar-mcp.html reading.html offline.html _headers .well-known/ucp",
     "check:hygiene": "node scripts/check-repository-hygiene.mjs",
     "check:assets": "node scripts/check-performance-budget.mjs",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:integration": "npx --no-install playwright install chromium && npx --no-install playwright test tests/integration/mobile-nav-and-accordion.spec.mjs --config=playwright.config.mjs",
     "audit:high": "npm audit --audit-level=high",
     "check:generated": "git diff --exit-code -- index.html work.html case-study-agentforge.html case-study-agentic.html case-study-apple-calendar-mcp.html reading.html offline.html _headers",
+    "check:generated": "git diff --exit-code -- index.html work.html case-study-agentforge.html case-study-agentic.html case-study-apple-calendar-mcp.html reading.html offline.html _headers .well-known/ucp",
     "check:hygiene": "node scripts/check-repository-hygiene.mjs",
     "check:assets": "node scripts/check-performance-budget.mjs",
     "check:accessibility": "npx --no-install playwright install chromium && npx --no-install playwright test tests/integration/accessibility-smoke.spec.mjs --config=playwright.config.mjs",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2297,6 +2297,13 @@ function buildSite({
       label: 'generated _headers',
       maxBytes: MAX_SITE_OUTPUT_BYTES
     });
+    const ucpProfile = readBuildText('src/.well-known/ucp', { rootDir: resolvedRoot });
+    entries.push({
+      path: path.join(resolvedRoot, '.well-known/ucp'),
+      bytes: ucpProfile,
+      label: 'generated UCP profile',
+      maxBytes: MAX_SITE_OUTPUT_BYTES
+    });
     publishSiteBundle({ rootDir: resolvedRoot, entries, writeFileImpl });
 
     log('Build complete: generated', pages.join(', '));

--- a/src/.well-known/ucp
+++ b/src/.well-known/ucp
@@ -1,0 +1,43 @@
+{
+  "protocol_version": "2026-04-08",
+  "services": {
+    "shopping": {
+      "spec": "https://ucp.dev/2026-04-08/specification/overview",
+      "schema": "https://ucp.dev/2026-04-08/services/shopping/embedded.openrpc.json"
+    }
+  },
+  "capabilities": {
+    "checkout": {
+      "spec": "https://ucp.dev/2026-04-08/specification/checkout",
+      "schema": "https://ucp.dev/2026-04-08/schemas/shopping/checkout.json"
+    }
+  },
+  "endpoints": {
+    "discovery": "https://leonardwong.tech/.well-known/ucp",
+    "content": "https://leonardwong.tech/api/scan"
+  },
+  "ucp": {
+    "version": "2026-04-08",
+    "services": {
+      "dev.ucp.shopping": [
+        {
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/overview",
+          "transport": "embedded",
+          "schema": "https://ucp.dev/2026-04-08/services/shopping/embedded.openrpc.json"
+        }
+      ]
+    },
+    "capabilities": {
+      "dev.ucp.shopping.checkout": [
+        {
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/checkout",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/checkout.json"
+        }
+      ]
+    },
+    "payment_handlers": {}
+  },
+  "signing_keys": []
+}

--- a/src/_headers.template
+++ b/src/_headers.template
@@ -35,3 +35,8 @@
 /offline
   Content-Security-Policy: default-src 'self'; script-src 'self'{{CSP_SCRIPT_HASHES}}; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
   Access-Control-Allow-Origin: https://leonardwong.tech
+
+/.well-known/ucp
+  Content-Type: application/json; charset=utf-8
+  Cache-Control: public, max-age=300, s-maxage=300
+  Access-Control-Allow-Origin: *

--- a/tests/security/ucp-discovery.test.mjs
+++ b/tests/security/ucp-discovery.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const projectRoot = path.resolve(import.meta.dirname, '../..');
+const sourcePath = path.join(projectRoot, 'src/.well-known/ucp');
+const generatedPath = path.join(projectRoot, '.well-known/ucp');
+const headersPath = path.join(projectRoot, '_headers');
+const canonicalPrefix = 'https://ucp.dev/2026-04-08/';
+
+function readProfile(filePath = generatedPath) {
+  assert.ok(fs.existsSync(filePath), `missing UCP profile: ${filePath}`);
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('UCP discovery profile exposes scanner and specification metadata', () => {
+  const profile = readProfile();
+
+  assert.equal(profile.protocol_version, '2026-04-08');
+  assert.ok(profile.services && typeof profile.services === 'object');
+  assert.ok(profile.capabilities && typeof profile.capabilities === 'object');
+  assert.ok(profile.endpoints && typeof profile.endpoints === 'object');
+  assert.ok(Object.keys(profile.services).length > 0);
+  assert.ok(Object.keys(profile.capabilities).length > 0);
+  assert.ok(Object.keys(profile.endpoints).length > 0);
+  Object.entries(profile.endpoints).forEach(([name, url]) => {
+    assert.equal(typeof url, 'string', `${name} endpoint must be a URL string`);
+    assert.match(url, /^https:\/\//, `${name} endpoint must use HTTPS`);
+  });
+
+  assert.equal(profile.endpoints.content, 'https://leonardwong.tech/api/scan');
+  assert.equal(profile.ucp?.version, profile.protocol_version);
+  assert.ok(profile.ucp?.services?.['dev.ucp.shopping']);
+  assert.ok(profile.ucp?.capabilities?.['dev.ucp.shopping.checkout']);
+  assert.deepEqual(profile.ucp?.payment_handlers, {});
+  assert.deepEqual(profile.signing_keys, []);
+});
+
+test('UCP discovery references only HTTPS canonical specifications and schemas', () => {
+  const profile = readProfile();
+  const references = [];
+
+  function collect(value, key = '') {
+    if (Array.isArray(value)) {
+      value.forEach((item) => collect(item, key));
+      return;
+    }
+    if (!value || typeof value !== 'object') {
+      if (['spec', 'schema'].includes(key)) references.push(value);
+      return;
+    }
+    Object.entries(value).forEach(([entryKey, entryValue]) => collect(entryValue, entryKey));
+  }
+
+  collect(profile);
+  assert.ok(references.length > 0);
+  references.forEach((url) => {
+    assert.equal(typeof url, 'string');
+    assert.match(url, new RegExp(`^${canonicalPrefix.replaceAll('.', '\\.')}`));
+    assert.match(url, /^https:\/\//);
+  });
+});
+
+test('generated UCP profile stays in sync with its source and is served as JSON', () => {
+  assert.equal(fs.readFileSync(generatedPath, 'utf8'), fs.readFileSync(sourcePath, 'utf8'));
+  const headers = fs.readFileSync(headersPath, 'utf8');
+  const block = headers.slice(headers.indexOf('/.well-known/ucp'));
+
+  assert.match(block, /Content-Type: application\/json; charset=utf-8/);
+  assert.match(block, /Cache-Control: public, max-age=300, s-maxage=300/);
+  assert.match(block, /Access-Control-Allow-Origin: \*/);
+});


### PR DESCRIPTION
## Summary

Publishes a Universal Commerce Protocol discovery document at /.well-known/ucp so agent-readiness scanners can discover the site’s commerce metadata and paid content endpoint.

## Changes

- Added source-backed UCP metadata with protocol version, shopping service, checkout capability, endpoints, and canonical UCP specification/schema references.
- Added generated /.well-known/ucp output and JSON/CORS/cache headers.
- Added build wiring and generated-file inventory coverage.
- Added regression tests for profile shape, HTTPS references, source/generated parity, and discovery headers.

## Why

Agents need a stable discovery document before they can identify the site’s UCP-compatible content-payment surface.

## Testing

- npm run build — passed on the working checkout
- npm run test:security — passed, 137/137 tests on the working checkout
- node --test tests/security/ucp-discovery.test.mjs — passed
- git diff --check — passed
- Canonical UCP specification and schema URLs verified with HTTP 200 responses

## Risk

Low. This adds static discovery metadata and build/test coverage without changing existing page behavior or payment processing logic.

## Rollback Plan

Revert this pull request or remove /.well-known/ucp and its source/build/header entries.

## Notes for Reviewers

Please verify the UCP profile fields and whether the configured /api/scan endpoint is the intended content-payment surface. The final IsItAgentReady commerce pass requires deployment to the public origin.

## Linked Issues

None.