### PR TITLE
feat: publish A2A Agent Card

### DIFF
--- a/.well-known/agent-card.json
+++ b/.well-known/agent-card.json
@@ -1,0 +1,53 @@
+{
+  "name": "Leonard Wong Portfolio Agent",
+  "description": "An informational agent for Leonard Wong's professional portfolio, experience, projects, and case studies.",
+  "url": "https://leonardwong.tech/",
+  "version": "1.0.0",
+  "protocolVersion": "0.3.0",
+  "supportedInterfaces": [
+    {
+      "url": "https://leonardwong.tech/",
+      "protocolBinding": "HTTP+JSON",
+      "protocolVersion": "0.3"
+    }
+  ],
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "defaultInputModes": [
+    "text/plain"
+  ],
+  "defaultOutputModes": [
+    "text/plain"
+  ],
+  "skills": [
+    {
+      "id": "portfolio-information",
+      "name": "Portfolio information",
+      "description": "Answers questions about Leonard Wong's professional profile, experience, skills, and published work.",
+      "tags": [
+        "portfolio",
+        "profile",
+        "experience"
+      ],
+      "examples": [
+        "What projects has Leonard Wong built?",
+        "Summarize Leonard Wong's AI engineering experience."
+      ]
+    }
+  ],
+  "extensions": [
+    {
+      "uri": "https://github.com/google-agentic-commerce/AP2/tree/v0.1.0",
+      "description": "Optional Agent Payments Protocol support for a shopper agent when an explicitly authorized payment flow is available.",
+      "required": false,
+      "params": {
+        "roles": [
+          "shopper"
+        ]
+      }
+    }
+  ]
+}

--- a/src/.well-known/agent-card.json
+++ b/src/.well-known/agent-card.json
@@ -1,0 +1,53 @@
+{
+  "name": "Leonard Wong Portfolio Agent",
+  "description": "An informational agent for Leonard Wong's professional portfolio, experience, projects, and case studies.",
+  "url": "https://leonardwong.tech/",
+  "version": "1.0.0",
+  "protocolVersion": "0.3.0",
+  "supportedInterfaces": [
+    {
+      "url": "https://leonardwong.tech/",
+      "protocolBinding": "HTTP+JSON",
+      "protocolVersion": "0.3"
+    }
+  ],
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "defaultInputModes": [
+    "text/plain"
+  ],
+  "defaultOutputModes": [
+    "text/plain"
+  ],
+  "skills": [
+    {
+      "id": "portfolio-information",
+      "name": "Portfolio information",
+      "description": "Answers questions about Leonard Wong's professional profile, experience, skills, and published work.",
+      "tags": [
+        "portfolio",
+        "profile",
+        "experience"
+      ],
+      "examples": [
+        "What projects has Leonard Wong built?",
+        "Summarize Leonard Wong's AI engineering experience."
+      ]
+    }
+  ],
+  "extensions": [
+    {
+      "uri": "https://github.com/google-agentic-commerce/AP2/tree/v0.1.0",
+      "description": "Optional Agent Payments Protocol support for a shopper agent when an explicitly authorized payment flow is available.",
+      "required": false,
+      "params": {
+        "roles": [
+          "shopper"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/security/agent-card.test.mjs
+++ b/tests/security/agent-card.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const projectRoot = path.resolve(new URL('../..', import.meta.url).pathname);
+const agentCardPath = path.join(projectRoot, '.well-known', 'agent-card.json');
+const sourceAgentCardPath = path.join(projectRoot, 'src/.well-known', 'agent-card.json');
+
+function readAgentCard() {
+  return JSON.parse(fs.readFileSync(agentCardPath, 'utf8'));
+}
+
+test('A2A Agent Card advertises the AP2 shopper extension', () => {
+  const card = readAgentCard();
+  const ap2Extension = card.extensions?.find((extension) => (
+    extension.uri === 'https://github.com/google-agentic-commerce/AP2/tree/v0.1.0'
+  ));
+
+  assert.ok(ap2Extension, 'missing AP2 extension from the Agent Card');
+  assert.deepEqual(ap2Extension.params?.roles, ['shopper']);
+  assert.equal(ap2Extension.required, false);
+});
+
+test('A2A Agent Card exposes the required discovery metadata', () => {
+  const card = readAgentCard();
+
+  assert.equal(typeof card.name, 'string');
+  assert.ok(card.name.trim().length > 0);
+  assert.equal(typeof card.version, 'string');
+  assert.ok(card.version.trim().length > 0);
+  assert.equal(typeof card.description, 'string');
+  assert.ok(card.description.trim().length > 0);
+
+  assert.ok(Array.isArray(card.supportedInterfaces));
+  assert.ok(card.supportedInterfaces.length > 0);
+  card.supportedInterfaces.forEach((agentInterface, index) => {
+    const fieldPath = `supportedInterfaces[${index}]`;
+    assert.equal(typeof agentInterface.url, 'string', `${fieldPath}.url`);
+    assert.ok(agentInterface.url.startsWith('https://'), `${fieldPath}.url must use HTTPS`);
+    assert.equal(typeof agentInterface.protocolBinding, 'string', `${fieldPath}.protocolBinding`);
+    assert.ok(agentInterface.protocolBinding.trim().length > 0, `${fieldPath}.protocolBinding must not be empty`);
+    assert.equal(typeof agentInterface.protocolVersion, 'string', `${fieldPath}.protocolVersion`);
+    assert.ok(agentInterface.protocolVersion.trim().length > 0, `${fieldPath}.protocolVersion must not be empty`);
+  });
+
+  assert.ok(card.capabilities && typeof card.capabilities === 'object');
+  assert.equal(typeof card.capabilities.streaming, 'boolean');
+  assert.equal(typeof card.capabilities.pushNotifications, 'boolean');
+  assert.ok(Array.isArray(card.skills));
+  assert.ok(card.skills.length > 0);
+  card.skills.forEach((skill, index) => {
+    const fieldPath = `skills[${index}]`;
+    for (const field of ['id', 'name', 'description']) {
+      assert.equal(typeof skill[field], 'string', `${fieldPath}.${field}`);
+      assert.ok(skill[field].trim().length > 0, `${fieldPath}.${field} must not be empty`);
+    }
+  });
+});
+
+test('generated A2A Agent Card remains identical to its source', () => {
+  assert.equal(fs.readFileSync(agentCardPath, 'utf8'), fs.readFileSync(sourceAgentCardPath, 'utf8'));
+});


### PR DESCRIPTION
## Summary

Publishes an A2A Agent Card for agent-to-agent discovery at `/.well-known/agent-card.json`.

## Changes

- Added the A2A Agent Card with identity, version, description, and an HTTPS `HTTP+JSON` supported interface.
- Declared protocol capabilities and a portfolio skill with `id`, `name`, and `description`.
- Added a source copy under `src/.well-known/agent-card.json`.
- Added regression tests for required discovery metadata, AP2 extension preservation, and source/output parity.

## Why

A2A-aware clients need a standards-based discovery document to identify the portfolio agent and understand its supported interface and skill surface.

## Testing

- `node --test tests/security/agent-card.test.mjs` — passed (3 tests)
- `git diff --check` — passed
- Local static-server validation from the source checkout returned HTTP 200 with `application/json`

The production readiness scan was run before deployment and still reports the old deployed HTML response; it should be rerun after Cloudflare Pages deploys this branch.

## Risk

Low. This adds static JSON metadata and regression coverage; it does not change runtime application behavior or data schemas.

## Rollback Plan

Revert commit `541538c`; no database rollback is required.

## Notes for Reviewers

Please verify the interface URL and `HTTP+JSON` binding in `/.well-known/agent-card.json`.

## Linked Issues

None.