### PR TITLE
feat: add Web Bot Auth identity and signing

### DIFF
--- a/.well-known/http-message-signatures-directory
+++ b/.well-known/http-message-signatures-directory
@@ -1,0 +1,13 @@
+{
+  "keys": [
+    {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "iS9xuNw_9CiU6niQTIB7GX1UD0VCi-S_VblvD7pjVlQ",
+      "kid": "leonardwong.tech",
+      "use": "sig",
+      "key_ops": ["verify"],
+      "alg": "EdDSA"
+    }
+  ]
+}

--- a/_headers
+++ b/_headers
@@ -35,3 +35,8 @@
 /offline
   Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-RBh5ZtcP26aZFp/EGYy/BT1gSD595lvp8sWO2T9xesI='; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
   Access-Control-Allow-Origin: https://leonardwong.tech
+
+/.well-known/http-message-signatures-directory
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600, must-revalidate

--- a/docs/security/web-bot-auth.md
+++ b/docs/security/web-bot-auth.md
@@ -1,0 +1,37 @@
+# Web Bot Auth
+
+The site publishes its HTTP Message Signatures verification key as a JWKS at
+`https://leonardwong.tech/.well-known/http-message-signatures-directory`.
+The directory currently exposes the Ed25519 key with key ID
+`leonardwong.tech`. The public JWK is safe to publish; the corresponding
+private JWK must remain in the bot or agent's secret store.
+
+Outbound bot and agent processes can use `scripts/web-bot-auth.mjs` to produce
+the HTTP Message Signature headers required by Web Bot Auth:
+
+```js
+import { signWebBotAuthRequest } from './scripts/web-bot-auth.mjs';
+
+const body = JSON.stringify({ message: 'hello' });
+const headers = signWebBotAuthRequest({
+  url: 'https://receiver.example/endpoint',
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body,
+  privateJwk: process.env.WEB_BOT_AUTH_PRIVATE_JWK
+});
+
+await fetch('https://receiver.example/endpoint', {
+  method: 'POST',
+  headers,
+  body
+});
+```
+
+The helper emits `Signature-Agent`, `Signature-Input`, and `Signature`
+headers. It signs the request method, target URI, signature-agent value, and,
+when a body is supplied, a SHA-256 `Content-Digest` using Ed25519. Keep
+`WEB_BOT_AUTH_PRIVATE_JWK` configured only in the outbound agent runtime; it is
+intentionally not stored in this static-site repository. Signatures are limited
+to a five-minute freshness window and include an `expires` parameter; receivers
+must enforce both `created` and `expires` to prevent replay.

--- a/scripts/web-bot-auth.mjs
+++ b/scripts/web-bot-auth.mjs
@@ -1,0 +1,166 @@
+import { createHash, createPrivateKey, sign as signBytes } from 'node:crypto';
+
+const DEFAULT_AGENT = 'https://leonardwong.tech';
+const DEFAULT_KEY_ID = 'leonardwong.tech';
+const DEFAULT_COMPONENTS = ['@method', '@target-uri', 'signature-agent'];
+const DEFAULT_MAX_AGE_SECONDS = 300;
+const CLOCK_SKEW_SECONDS = 30;
+const COMPONENT_PATTERN = /^(?:@[A-Za-z0-9-]+|[!#$%&'*+.^_`|~0-9A-Za-z-]+)$/u;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/u;
+
+function quote(value) {
+  const text = String(value).replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+  return `"${text}"`;
+}
+
+function normalizeHeaders(headers = {}) {
+  return new Map(Object.entries(headers).map(([name, value]) => [name.toLowerCase(), String(value)]));
+}
+
+function serializeSignatureParams(components, { created, expires, keyId, algorithm }) {
+  const componentList = components.map(quote).join(' ');
+  const expiry = Number.isSafeInteger(expires) ? `;expires=${expires}` : '';
+  return `(${componentList});created=${created}${expiry};keyid=${quote(keyId)};alg=${quote(algorithm)}`;
+}
+
+function signatureBase({ method, url, headers, components, signatureParams }) {
+  const values = components.map((component) => {
+    if (component === '@method') return `"@method": ${method.toUpperCase()}`;
+    if (component === '@target-uri') return `"@target-uri": ${url}`;
+    return `"${component}": ${headers.get(component) ?? ''}`;
+  });
+  values.push(`"@signature-params": ${signatureParams}`);
+  return values.join('\n');
+}
+
+function validateTargetUrl(value) {
+  if (typeof value !== 'string') {
+    throw new Error('url must be an HTTPS URL');
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error('url must be an HTTPS URL');
+  }
+  if (
+    parsed.protocol !== 'https:' ||
+    parsed.username ||
+    parsed.password ||
+    parsed.hash ||
+    CONTROL_CHARACTER_PATTERN.test(value)
+  ) {
+    throw new Error('url must be an HTTPS URL without credentials or fragments');
+  }
+  return parsed.toString();
+}
+
+function validateSafeValue(value, fieldName) {
+  if (typeof value !== 'string' || value.length === 0 || CONTROL_CHARACTER_PATTERN.test(value)) {
+    throw new Error(`${fieldName} must be a non-empty string without control characters`);
+  }
+  return value;
+}
+
+function validateComponents(components) {
+  if (!Array.isArray(components) || components.length === 0 || components.some((component) => (
+    typeof component !== 'string' ||
+    !COMPONENT_PATTERN.test(component) ||
+    component !== component.trim()
+  ))) {
+    throw new Error('components must be a non-empty list of valid HTTP signature components');
+  }
+  if (new Set(components).size !== components.length) {
+    throw new Error('components must not contain duplicates');
+  }
+  const normalized = components.map((component) => component.toLowerCase());
+  if (new Set(normalized).size !== normalized.length) {
+    throw new Error('components must not contain duplicates');
+  }
+  return normalized;
+}
+
+function loadPrivateKey(privateJwk = process.env.WEB_BOT_AUTH_PRIVATE_JWK) {
+  if (!privateJwk) {
+    throw new Error('WEB_BOT_AUTH_PRIVATE_JWK is required to sign Web Bot Auth requests');
+  }
+
+  let jwk;
+  try {
+    jwk = typeof privateJwk === 'string' ? JSON.parse(privateJwk) : privateJwk;
+  } catch {
+    throw new Error('WEB_BOT_AUTH_PRIVATE_JWK must contain valid JSON');
+  }
+
+  if (!jwk || jwk.kty !== 'OKP' || jwk.crv !== 'Ed25519' || typeof jwk.d !== 'string') {
+    throw new Error('WEB_BOT_AUTH_PRIVATE_JWK must be an Ed25519 private JWK');
+  }
+  return createPrivateKey({ key: jwk, format: 'jwk' });
+}
+
+/**
+ * Sign an outbound HTTP request using the Web Bot Auth HTTP Message Signature
+ * profile. Keep the private JWK in a secret store or environment variable.
+ */
+export function signWebBotAuthRequest({
+  url,
+  method = 'GET',
+  headers = {},
+  body,
+  privateJwk,
+  agent = DEFAULT_AGENT,
+  keyId = DEFAULT_KEY_ID,
+  created = Math.floor(Date.now() / 1000),
+  components = DEFAULT_COMPONENTS,
+  maxAgeSeconds = DEFAULT_MAX_AGE_SECONDS
+} = {}) {
+  const targetUrl = validateTargetUrl(url);
+  validateSafeValue(agent, 'agent');
+  validateSafeValue(keyId, 'keyId');
+  validateSafeValue(method, 'method');
+  if (!/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/u.test(method)) {
+    throw new Error('method must be a valid HTTP method token');
+  }
+  if (!Number.isSafeInteger(created) || created <= 0) {
+    throw new Error('created must be a positive integer timestamp');
+  }
+  if (!Number.isSafeInteger(maxAgeSeconds) || maxAgeSeconds <= 0 || maxAgeSeconds > DEFAULT_MAX_AGE_SECONDS) {
+    throw new Error(`maxAgeSeconds must be an integer between 1 and ${DEFAULT_MAX_AGE_SECONDS}`);
+  }
+  const now = Math.floor(Date.now() / 1000);
+  if (created < now - maxAgeSeconds || created > now + CLOCK_SKEW_SECONDS) {
+    throw new Error('created timestamp is outside the allowed freshness window');
+  }
+  const expires = created + maxAgeSeconds;
+  const signedComponents = validateComponents(components);
+
+  const normalized = normalizeHeaders(headers);
+  if (body !== undefined) {
+    const digest = createHash('sha256').update(Buffer.from(body)).digest('base64');
+    normalized.set('content-digest', `sha-256=:${digest}:`);
+    if (!signedComponents.includes('content-digest')) {
+      signedComponents.push('content-digest');
+    }
+  }
+  normalized.set('signature-agent', agent);
+  const algorithm = 'ed25519';
+  const signatureParams = serializeSignatureParams(signedComponents, {
+    created,
+    expires,
+    keyId,
+    algorithm
+  });
+  const base = signatureBase({ method, url: targetUrl, headers: normalized, components: signedComponents, signatureParams });
+  const signature = signBytes(null, Buffer.from(base, 'utf8'), loadPrivateKey(privateJwk)).toString('base64');
+
+  normalized.delete('signature-agent');
+  return {
+    ...Object.fromEntries(normalized),
+    'Signature-Agent': agent,
+    'Signature-Input': `sig1=${signatureParams}`,
+    Signature: `sig1=:${signature}:`
+  };
+}
+
+export { DEFAULT_AGENT, DEFAULT_KEY_ID, DEFAULT_COMPONENTS, serializeSignatureParams, signatureBase };

--- a/src/.well-known/http-message-signatures-directory
+++ b/src/.well-known/http-message-signatures-directory
@@ -1,0 +1,13 @@
+{
+  "keys": [
+    {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "iS9xuNw_9CiU6niQTIB7GX1UD0VCi-S_VblvD7pjVlQ",
+      "kid": "leonardwong.tech",
+      "use": "sig",
+      "key_ops": ["verify"],
+      "alg": "EdDSA"
+    }
+  ]
+}

--- a/src/_headers.template
+++ b/src/_headers.template
@@ -35,3 +35,8 @@
 /offline
   Content-Security-Policy: default-src 'self'; script-src 'self'{{CSP_SCRIPT_HASHES}}; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
   Access-Control-Allow-Origin: https://leonardwong.tech
+
+/.well-known/http-message-signatures-directory
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600, must-revalidate

--- a/tests/security/web-bot-auth.test.mjs
+++ b/tests/security/web-bot-auth.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { createPublicKey, generateKeyPairSync, verify as verifyBytes } from 'node:crypto';
+import { signWebBotAuthRequest, signatureBase } from '../../scripts/web-bot-auth.mjs';
+
+const root = path.resolve(new URL('../..', import.meta.url).pathname);
+const directoryPath = path.join(root, '.well-known/http-message-signatures-directory');
+const sourceDirectoryPath = path.join(root, 'src/.well-known/http-message-signatures-directory');
+const directory = JSON.parse(fs.readFileSync(directoryPath, 'utf8'));
+const publicJwk = directory.keys[0];
+const headersTemplate = fs.readFileSync(path.join(root, 'src/_headers.template'), 'utf8');
+
+test('publishes a Web Bot Auth JWKS with an Ed25519 verification key', () => {
+  assert.ok(Array.isArray(directory.keys));
+  assert.ok(directory.keys.length > 0);
+  assert.deepEqual(
+    { kty: publicJwk.kty, crv: publicJwk.crv, use: publicJwk.use, key_ops: publicJwk.key_ops, alg: publicJwk.alg },
+    { kty: 'OKP', crv: 'Ed25519', use: 'sig', key_ops: ['verify'], alg: 'EdDSA' }
+  );
+  assert.equal(typeof publicJwk.x, 'string');
+  assert.equal(typeof publicJwk.kid, 'string');
+  assert.equal('d' in publicJwk, false);
+  assert.doesNotThrow(() => createPublicKey({ key: publicJwk, format: 'jwk' }));
+  assert.match(headersTemplate, /\/.well-known\/http-message-signatures-directory[\s\S]*Content-Type: application\/json/i);
+  assert.match(headersTemplate, /\/.well-known\/http-message-signatures-directory[\s\S]*Access-Control-Allow-Origin: \*/i);
+});
+
+test('generated Web Bot Auth directory remains identical to its source', () => {
+  assert.equal(fs.readFileSync(directoryPath, 'utf8'), fs.readFileSync(sourceDirectoryPath, 'utf8'));
+});
+
+test('signs a request with the Web Bot Auth header set', () => {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  const privateJwk = privateKey.export({ format: 'jwk' });
+  const created = Math.floor(Date.now() / 1000);
+  const headers = signWebBotAuthRequest({
+    url: 'https://example.com/resource',
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{"ok":true}',
+    privateJwk,
+    created
+  });
+
+  assert.equal(headers['Signature-Agent'], 'https://leonardwong.tech');
+  assert.match(headers['Signature-Input'], new RegExp(`^sig1=\\("@method" "@target-uri" "signature-agent" "content-digest"\\);created=${created};expires=${created + 300};`));
+  assert.match(headers['content-digest'], /^sha-256=:[A-Za-z0-9+/]+=*:/);
+  assert.match(headers.Signature, /^sig1=:[A-Za-z0-9+/]+=*:[.]?$/);
+
+  const signatureParams = headers['Signature-Input'].slice('sig1='.length);
+  const base = signatureBase({
+    method: 'POST',
+    url: 'https://example.com/resource',
+    headers: new Map([
+      ['signature-agent', headers['Signature-Agent']],
+      ['content-digest', headers['content-digest']]
+    ]),
+    components: ['@method', '@target-uri', 'signature-agent', 'content-digest'],
+    signatureParams
+  });
+  const signature = Buffer.from(headers.Signature.slice('sig1=:'.length, -1), 'base64');
+  assert.equal(verifyBytes(null, Buffer.from(base), publicKey, signature), true);
+});
+
+test('signature base includes the signature parameters line', () => {
+  const base = signatureBase({
+    method: 'GET',
+    url: 'https://example.com/path',
+    headers: new Map([['signature-agent', 'https://leonardwong.tech']]),
+    components: ['@method', '@target-uri', 'signature-agent'],
+    signatureParams: '("@method" "@target-uri" "signature-agent");created=1;keyid="leonardwong.tech";alg="ed25519"'
+  });
+  assert.match(base, /"@method": GET/);
+  assert.match(base, /"@target-uri": https:\/\/example\.com\/path/);
+  assert.match(base, /"@signature-params":/);
+});
+
+test('rejects unsafe targets, components, and stale timestamps', () => {
+  const { privateKey } = generateKeyPairSync('ed25519');
+  const privateJwk = privateKey.export({ format: 'jwk' });
+  const sign = (options = {}) => signWebBotAuthRequest({
+    url: 'https://example.com/resource',
+    privateJwk,
+    ...options
+  });
+
+  assert.throws(() => sign({ url: 'https://user:password@example.com/resource' }), /without credentials/);
+  assert.throws(() => sign({ url: 'https://example.com/resource#fragment' }), /without credentials/);
+  assert.throws(() => sign({ components: ['@method', 'x\n-injected'] }), /valid HTTP signature components/);
+  assert.throws(() => sign({ created: Math.floor(Date.now() / 1000) - 301 }), /freshness window/);
+  assert.throws(() => sign({ agent: 'https://agent.example\nInjected: value' }), /control characters/);
+});


### PR DESCRIPTION
## Summary

Adds Web Bot Auth support for the portfolio site. The site now publishes an Ed25519 JWKS at the IETF HTTP Message Signatures directory path, and outbound bot or agent processes can sign requests with the matching helper.

## Changes

- Publish the public verification key at `/.well-known/http-message-signatures-directory` and keep a matching source copy under `src/.well-known/`.
- Add Cloudflare Pages JSON, CORS, and cache headers for the directory.
- Add an Ed25519 HTTP Message Signature helper that emits `Signature-Agent`, `Signature-Input`, and `Signature` headers.
- Include a SHA-256 `Content-Digest` when signing a request body.
- Add documentation and cryptographic regression tests, including unsafe-target and freshness checks.

## Why

Receiving sites need a stable way to identify and verify requests from the site's bot or agent. The public key is safe to publish; the corresponding private JWK remains an outbound-runtime secret.

## Testing

- `node --test tests/security/web-bot-auth.test.mjs` — passed (5 tests)
- `npm run build` — passed
- `git diff --check` — passed
- Generated-page diff check — passed
- Full `npm run test:security` was attempted in the isolated PR worktree but could not complete because that fresh worktree has no installed `yaml` and `hono` dependencies; the focused Web Bot Auth suite passes.

## Screenshots / Recordings

Not applicable.

## Risk

Low. This adds a public JSON discovery resource, static response headers, and an opt-in signing helper. No private key is committed and no existing page behavior is changed.

## Rollback Plan

Revert this commit or remove the published directory and signing helper. No database migration or irreversible external change is required.

## Notes for Reviewers

- Configure `WEB_BOT_AUTH_PRIVATE_JWK` only in the outbound bot or agent runtime, using the private key matching the published `kid`.
- Please verify the HTTP Message Signature component set and the Cloudflare Pages header behavior for the extensionless well-known path.

## Linked Issues

None.
